### PR TITLE
some header cleanups for recent commit

### DIFF
--- a/src/core/download.cc
+++ b/src/core/download.cc
@@ -36,9 +36,7 @@
 
 #include "config.h"
 
-#include <sigc++/adaptors/bind.h>
-#include <sigc++/adaptors/hide.h>
-#include <sigc++/signal.h>
+#include <list>
 #include <rak/file_stat.h>
 #include <rak/functional.h>
 #include <rak/path.h>

--- a/src/core/download.h
+++ b/src/core/download.h
@@ -37,7 +37,6 @@
 #ifndef RTORRENT_CORE_DOWNLOAD_H
 #define RTORRENT_CORE_DOWNLOAD_H
 
-#include <sigc++/connection.h>
 #include <torrent/download.h>
 #include <torrent/download_info.h>
 #include <torrent/hash_string.h>


### PR DESCRIPTION
The main reason is to allow rtorrent to build successfully again, and header cleanups are also good.
