### PR TITLE
fix non-posix conformant header aliases

### DIFF
--- a/src/display/canvas.cc
+++ b/src/display/canvas.cc
@@ -38,7 +38,7 @@
 
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <sys/termios.h>
+#include <termios.h>
 #include <torrent/exceptions.h>
 
 #include "canvas.h"

--- a/src/input/path_input.cc
+++ b/src/input/path_input.cc
@@ -43,12 +43,8 @@
 
 #include <sys/types.h>
 
-#ifdef __sun__
-  #include <dirent.h>
-  #include <sys/stat.h>
-#else
-  #include <sys/dir.h>
-#endif
+#include <dirent.h>
+#include <sys/stat.h>
 
 #include "path_input.h"
 

--- a/src/signal_handler.h
+++ b/src/signal_handler.h
@@ -37,7 +37,7 @@
 #ifndef RTORRENT_SIGNAL_HANDLER_H
 #define RTORRENT_SIGNAL_HANDLER_H
 
-#include <sys/signal.h>
+#include <signal.h>
 #include <sigc++/functors/slot.h>
 
 class SignalHandler {


### PR DESCRIPTION
bogus headers like sys/signal.h are simple wrappers for the real
thing, existing on some legacy libcs like glibc.

they're missing on musl, which is posix compliant.

closes #124
