### PR TITLE
Fix warning on automake-1.12.4

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,4 +52,4 @@ rtorrent_LDADD = \
 rtorrent_SOURCES = \
 	main.cc
 
-INCLUDES = -I$(srcdir) -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -30,4 +30,4 @@ libsub_core_a_SOURCES = \
 	view_manager.cc \
 	view_manager.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/display/Makefile.am
+++ b/src/display/Makefile.am
@@ -50,4 +50,4 @@ libsub_display_a_SOURCES = \
 	window_tracker_list.cc \
 	window_tracker_list.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/input/Makefile.am
+++ b/src/input/Makefile.am
@@ -12,4 +12,4 @@ libsub_input_a_SOURCES = \
 	text_input.cc \
 	text_input.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/rpc/Makefile.am
+++ b/src/rpc/Makefile.am
@@ -27,4 +27,4 @@ libsub_rpc_a_SOURCES = \
 	xmlrpc.h \
 	xmlrpc.cc
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/ui/Makefile.am
+++ b/src/ui/Makefile.am
@@ -30,4 +30,4 @@ libsub_ui_a_SOURCES = \
 	root.cc \
 	root.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -11,4 +11,4 @@ libsub_utils_a_SOURCES = \
 	socket_fd.cc \
 	socket_fd.h
 
-INCLUDES = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)
+AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,4 +25,4 @@ rtorrentTest_SOURCES = \
 rtorrentTest_CXXFLAGS = $(CPPUNIT_CFLAGS)
 rtorrentTest_LDFLAGS = $(CPPUNIT_LIBS)  -ldl
 
-INCLUDES = -I$(srcdir) -I$(top_srcdir) -I$(top_srcdir)/src
+AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir) -I$(top_srcdir)/src


### PR DESCRIPTION
warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
