### PR TITLE
Added config parameter network.http.ssl_verify_host to support certificates

### DIFF
--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -274,6 +274,8 @@ initialize_command_network() {
   CMD2_ANY_VALUE_V ("network.http.ssl_verify_peer.set",   tr1::bind(&core::CurlStack::set_ssl_verify_peer, httpStack, tr1::placeholders::_2));
   CMD2_ANY         ("network.http.dns_cache_timeout",     tr1::bind(&core::CurlStack::dns_timeout, httpStack));
   CMD2_ANY_VALUE_V ("network.http.dns_cache_timeout.set", tr1::bind(&core::CurlStack::set_dns_timeout, httpStack, tr1::placeholders::_2));
+  CMD2_ANY         ("network.http.ssl_verify_host",       tr1::bind(&core::CurlStack::ssl_verify_host, httpStack));
+  CMD2_ANY_VALUE_V ("network.http.ssl_verify_host.set",   tr1::bind(&core::CurlStack::set_ssl_verify_host, httpStack, tr1::placeholders::_2));
 
   CMD2_ANY         ("network.send_buffer.size",        tr1::bind(&torrent::ConnectionManager::send_buffer_size, cm));
   CMD2_ANY_VALUE_V ("network.send_buffer.size.set",    tr1::bind(&torrent::ConnectionManager::set_send_buffer_size, cm, tr1::placeholders::_2));

--- a/src/core/curl_stack.cc
+++ b/src/core/curl_stack.cc
@@ -52,7 +52,8 @@ CurlStack::CurlStack() :
   m_active(0),
   m_maxActive(32),
   m_ssl_verify_peer(true),
-  m_dns_timeout(60) {
+  m_dns_timeout(60),
+  m_ssl_verify_host(2) {
 
   m_taskTimeout.slot() = std::tr1::bind(&CurlStack::receive_timeout, this);
 
@@ -167,6 +168,7 @@ CurlStack::add_get(CurlGet* get) {
 
   curl_easy_setopt(get->handle(), CURLOPT_SSL_VERIFYPEER, (long)m_ssl_verify_peer); 
   curl_easy_setopt(get->handle(), CURLOPT_DNS_CACHE_TIMEOUT, m_dns_timeout);
+  curl_easy_setopt(get->handle(), CURLOPT_SSL_VERIFYHOST, m_ssl_verify_host);
 
   base_type::push_back(get);
 

--- a/src/core/curl_stack.h
+++ b/src/core/curl_stack.h
@@ -106,6 +106,9 @@ class CurlStack : std::deque<CurlGet*> {
   long                dns_timeout() const                    { return m_dns_timeout; }
   void                set_dns_timeout(long timeout)          { m_dns_timeout = timeout; }
 
+  long                ssl_verify_host() const                { return m_ssl_verify_host; }
+  void                set_ssl_verify_host(long s)            { m_ssl_verify_host = s; }
+
   static void         global_init();
   static void         global_cleanup();
 
@@ -140,6 +143,7 @@ class CurlStack : std::deque<CurlGet*> {
 
   bool                m_ssl_verify_peer;
   long                m_dns_timeout;
+  long                m_ssl_verify_host;
 };
 
 }


### PR DESCRIPTION
Added config parameter network.http.ssl_verify_host to support certificates
with a mismatched or empty CN. Default is 2 (verify name match). Use 1 to simply
verify the presence of a name or 0 to allow for missing names.
