### PR TITLE
d.timestamp.finished for create torrent

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -273,6 +273,7 @@ main(int argc, char** argv) {
 
        "method.set_key = event.download.resumed,   !_timestamp, ((d.timestamp.started.set_if_z, ((system.time)) ))\n"
        "method.set_key = event.download.finished,  !_timestamp, ((d.timestamp.finished.set_if_z, ((system.time)) ))\n"
+       "method.set_key = event.download.hash_done, !_timestamp, {(branch,((d.complete)),((d.timestamp.finished.set_if_z,(system.time))))}\n"
 
        "method.insert.c_simple = group.insert_persistent_view,"
        "((view.add,((argument.0)))),((view.persistent,((argument.0)))),((group.insert,((argument.0)),((argument.0))))\n"


### PR DESCRIPTION
English (translate):
Adding initialization d.timestamp.finished at the torrent download but is not set seeding. For example when we create a torrent, it is not downloaded.

French:
Ajout de l'initialisation d.timestamp.finished lors que le torrent n'est pas télécharger mais mis en seeding. Par exemple lors que l'on créer un torrent, celui ci n'est pas télécharger.
