### PR TITLE
don't depend on dirent DT_DIR

### DIFF
--- a/src/input/path_input.cc
+++ b/src/input/path_input.cc
@@ -75,7 +75,11 @@ PathInput::pressed(int key) {
 
 struct _transform_filename {
   void operator () (utils::directory_entry& entry) {
+#ifdef __sun__
+    if (entry.d_type & S_IFDIR)
+#else
     if (entry.d_type == DT_DIR)
+#endif
       entry.d_name += '/';
   }
 };


### PR DESCRIPTION
Compilation on illumos fails due to DT_DIR not being defined. utils/directory.cc already has code which handles the lack of the d_type member of struct dirent under #ifdef __sun__, so I just extended that logic here.