### PR TITLE
Try use pkg-config to detect ncurses libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,15 +30,21 @@ TORRENT_WITHOUT_STATVFS
 TORRENT_WITHOUT_STATFS
 
 AX_PTHREAD([], AC_MSG_ERROR([requires pthread]))
-AX_WITH_CURSES
-
-if test "x$ax_cv_ncursesw" != xyes && test "x$ax_cv_ncurses" != xyes; then
-   AC_MSG_ERROR([requires either NcursesW or Ncurses library])
-fi
+PKG_CHECK_MODULES([CURSES],[ncursesw],[
+	AC_DEFINE(HAVE_NCURSESW_CURSES_H, 1)
+	],
+	[PKG_CHECK_MODULES([CURSES],[ncurses],[
+		AC_DEFINE(HAVE_NCURSES_H, 1)
+		],
+		[AX_WITH_CURSES
+		if test "x$ax_cv_ncursesw" != xyes && test "x$ax_cv_ncurses" != xyes; then
+			AC_MSG_ERROR([requires either NcursesW or Ncurses library])
+		fi])
+	])
 
 CFLAGS="$CFLAGS $PTHREAD_CFLAGS $CURSES_CFLAGS"
 CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS $CURSES_CFLAGS"
-LIBS="$PTHREAD_LIBS $CURSES_LIB $LIBS"
+LIBS="$PTHREAD_LIBS $CURSES_LIB $CURSES_LIBS $LIBS"
 
 PKG_CHECK_MODULES([libcurl], libcurl >= 7.15.4,
 	          CXXFLAGS="$CXXFLAGS $libcurl_CFLAGS";


### PR DESCRIPTION
Modern ncurses version provide a pkg-config interface, so let's try to
use it first. This also helps when ncurses provides functions inside
libtinfo.so and thus needs to be linked against it as well.

Signed-off-by: Justin Lecher <jlec@gentoo.org>