### PR TITLE
change *dl_rate() to *down_rate()

### DIFF
--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -419,7 +419,7 @@ DownloadFactory::initialize_rtorrent(Download* download, torrent::Object* rtorre
     download->info()->mutable_up_rate()->set_total(rtorrent->get_key_value("total_uploaded"));
 
   if (rtorrent->has_key_value("total_downloaded"))
-    download->info()->mutable_dl_rate()->set_total(rtorrent->get_key_value("total_downloaded"));
+    download->info()->mutable_down_rate()->set_total(rtorrent->get_key_value("total_downloaded"));
 
   if (rtorrent->has_key_value("chunks_done") && rtorrent->has_key_value("chunks_wanted"))
     download->download()->set_chunks_done(rtorrent->get_key_value("chunks_done"), rtorrent->get_key_value("chunks_wanted"));

--- a/src/core/download_store.cc
+++ b/src/core/download_store.cc
@@ -140,7 +140,7 @@ DownloadStore::save(Download* d, int flags) {
   rtorrent_base->insert_key("chunks_done",    d->download()->file_list()->completed_chunks());
   rtorrent_base->insert_key("chunks_wanted",  d->download()->data()->wanted_chunks());
   rtorrent_base->insert_key("total_uploaded", d->info()->up_rate()->total());
-  rtorrent_base->insert_key("total_downloaded", d->info()->dl_rate()->total());
+  rtorrent_base->insert_key("total_downloaded", d->info()->down_rate()->total());
 
   // Don't save for completed torrents when we've cleared the uncertain_pieces.
   torrent::resume_save_progress(*d->download(), *resume_base);


### PR DESCRIPTION
Fixes build issues created by https://github.com/rakshasa/rtorrent/commit/9647749b01feafa709845b63f38f956c159711e9 by using the correct libtorrent function names.