### PR TITLE
Allow rtorrent to run as a daemon, slightly modified version of #111

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -135,7 +135,7 @@ check_name(const std::string& str) {
     throw torrent::input_error("Non-alphanumeric characters found.");
 
   return str;
-}  
+}
 
 torrent::Object
 group_insert(const torrent::Object::list_type& args) {
@@ -158,7 +158,7 @@ group_insert(const torrent::Object::list_type& args) {
 
   if (rpc::call_command_value("method.use_intermediate") == 1) {
     // Deprecated in 0.7.0:
-    
+
     CMD2_REDIRECT_GENERIC_STR("group." + name + ".view",          "group2." + name + ".view");
     CMD2_REDIRECT_GENERIC_STR("group." + name + ".view.set",      "group2." + name + ".view.set");
     CMD2_REDIRECT_GENERIC_STR("group." + name + ".ratio.min",     "group2." + name + ".ratio.min");
@@ -170,7 +170,7 @@ group_insert(const torrent::Object::list_type& args) {
 
   } if (rpc::call_command_value("method.use_intermediate") == 2) {
     // Deprecated in 0.7.0:
-    
+
     CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".view",          "group2." + name + ".view");
     CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".view.set",      "group2." + name + ".view.set");
     CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".ratio.min",     "group2." + name + ".ratio.min");
@@ -215,9 +215,9 @@ torrent::Object
 cmd_file_append(const torrent::Object::list_type& args) {
   if (args.empty())
     throw torrent::input_error("Invalid number of arguments.");
-  
+
   FILE* output = fopen(args.front().as_string().c_str(), "a");
-  
+
   if (output == NULL)
     throw torrent::input_error("Could not append to file '" + args.front().as_string() + "': " + rak::error_number::current().c_str());
 
@@ -265,7 +265,7 @@ initialize_command_local() {
   CMD2_ANY         ("system.time_usec",                std::bind(&rak::timer::current_usec));
 
   CMD2_ANY_VALUE_V ("system.umask.set",                std::bind(&umask, std::placeholders::_2));
-  
+
   CMD2_VAR_BOOL    ("system.use_daemon",               false);
 
   CMD2_ANY         ("system.cwd",                      std::bind(&system_get_cwd));

--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -265,6 +265,8 @@ initialize_command_local() {
   CMD2_ANY         ("system.time_usec",                std::bind(&rak::timer::current_usec));
 
   CMD2_ANY_VALUE_V ("system.umask.set",                std::bind(&umask, std::placeholders::_2));
+  
+  CMD2_VAR_BOOL    ("system.use_daemon",               false);
 
   CMD2_ANY         ("system.cwd",                      std::bind(&system_get_cwd));
   CMD2_ANY_STRING  ("system.cwd.set",                  std::bind(&system_set_cwd, std::placeholders::_2));

--- a/src/control.cc
+++ b/src/control.cc
@@ -118,7 +118,9 @@ Control::initialize() {
 
   m_ui->init(this);
 
-  m_inputStdin->insert(torrent::main_thread()->poll());
+  if(!display::Canvas::daemon()) {
+    m_inputStdin->insert(torrent::main_thread()->poll());
+  }
 }
 
 void
@@ -128,7 +130,9 @@ Control::cleanup() {
 
   priority_queue_erase(&taskScheduler, &m_taskShutdown);
 
-  m_inputStdin->remove(torrent::main_thread()->poll());
+  if(!display::Canvas::daemon()) {
+    m_inputStdin->remove(torrent::main_thread()->poll());
+  }
 
   m_core->download_store()->disable();
 

--- a/src/control.cc
+++ b/src/control.cc
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -138,7 +138,7 @@ Control::cleanup() {
 
   m_ui->cleanup();
   m_core->cleanup();
-  
+
   display::Canvas::erase_std();
   display::Canvas::refresh_std();
   display::Canvas::do_update();

--- a/src/display/canvas.cc
+++ b/src/display/canvas.cc
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -104,7 +104,7 @@ void
 Canvas::initialize() {
   if (m_isInitialized)
     return;
-  
+
   m_isDaemon = rpc::call_command_value("system.use_daemon");
 
   m_isInitialized = true;
@@ -123,7 +123,7 @@ void
 Canvas::cleanup() {
   if (!m_isInitialized)
     return;
-  
+
   m_isInitialized = false;
 
   if (!m_isDaemon) {

--- a/src/display/canvas.cc
+++ b/src/display/canvas.cc
@@ -41,54 +41,63 @@
 #include <termios.h>
 #include <torrent/exceptions.h>
 
+#include "rpc/parse_commands.h"
+
 #include "canvas.h"
 
 namespace display {
 
 bool Canvas::m_isInitialized = false;
+bool Canvas::m_isDaemon = false;
 
-Canvas::Canvas(int x, int y, int width, int height) :
-  m_window(newwin(height, width, y, x)) {
+Canvas::Canvas(int x, int y, int width, int height) {
+  if (!m_isDaemon) {
+      m_window = newwin(height, width, y, x);
 
-  if (m_window == NULL)
-    throw torrent::internal_error("Could not allocate ncurses canvas.");
+      if (m_window == NULL)
+        throw torrent::internal_error("Could not allocate ncurses canvas.");
+  }
 }
 
 void
 Canvas::resize(int x, int y, int w, int h) {
-  wresize(m_window, h, w);
-  mvwin(m_window, y, x);
+  if (!m_isDaemon) {
+    wresize(m_window, h, w);
+    mvwin(m_window, y, x);
+  }
 }
 
 void
 Canvas::print_attributes(unsigned int x, unsigned int y, const char* first, const char* last, const attributes_list* attributes) {
-  move(x, y);
+  if (!m_isDaemon) {
+    move(x, y);
 
-  attr_t org_attr;
-  short org_pair;
-  wattr_get(m_window, &org_attr, &org_pair, NULL);
+    attr_t org_attr;
+    short org_pair;
+    wattr_get(m_window, &org_attr, &org_pair, NULL);
 
-  attributes_list::const_iterator attrItr = attributes->begin();
-  wattr_set(m_window, Attributes::a_normal, Attributes::color_default, NULL);
+    attributes_list::const_iterator attrItr = attributes->begin();
+    wattr_set(m_window, Attributes::a_normal, Attributes::color_default, NULL);
 
-  while (first != last) {
-    const char* next = last;
+    while (first != last) {
+      const char* next = last;
 
-    if (attrItr != attributes->end()) {
-      next = attrItr->position();
+      if (attrItr != attributes->end()) {
+        next = attrItr->position();
 
-      if (first >= next) {
-        wattr_set(m_window, attrItr->attributes(), attrItr->colors(), NULL);
-        ++attrItr;
+        if (first >= next) {
+          wattr_set(m_window, attrItr->attributes(), attrItr->colors(), NULL);
+          ++attrItr;
+        }
       }
+
+      print("%.*s", next - first, first);
+      first = next;
     }
 
-    print("%.*s", next - first, first);
-    first = next;
+    // Reset the color.
+    wattr_set(m_window, org_attr, org_pair, NULL);
   }
-
-  // Reset the color.
-  wattr_set(m_window, org_attr, org_pair, NULL);
 }
 
 void
@@ -96,14 +105,18 @@ Canvas::initialize() {
   if (m_isInitialized)
     return;
   
+  m_isDaemon = rpc::call_command_value("system.use_daemon");
+
   m_isInitialized = true;
 
-  initscr();
-  raw();
-  noecho();
-  nodelay(stdscr, TRUE);
-  keypad(stdscr, TRUE);
-  curs_set(0);
+  if (!m_isDaemon) {
+    initscr();
+    raw();
+    noecho();
+    nodelay(stdscr, TRUE);
+    keypad(stdscr, TRUE);
+    curs_set(0);
+  }
 }
 
 void
@@ -113,18 +126,21 @@ Canvas::cleanup() {
   
   m_isInitialized = false;
 
-  noraw();
-  endwin();
+  if (!m_isDaemon) {
+    noraw();
+    endwin();
+  }
 }
 
 std::pair<int, int>
 Canvas::term_size() {
   struct winsize ws;
 
-  if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) == 0)
-    return std::pair<int, int>(ws.ws_col, ws.ws_row);
-  else
-    return std::pair<int, int>(80, 24);
+  if (!m_isDaemon) {
+    if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) == 0)
+      return std::pair<int, int>(ws.ws_col, ws.ws_row);
+  }
+  return std::pair<int, int>(80, 24);
 }
 
 }

--- a/src/display/canvas.h
+++ b/src/display/canvas.h
@@ -49,37 +49,37 @@ public:
   typedef std::vector<Attributes> attributes_list;
 
   Canvas(int x = 0, int y = 0, int width = 0, int height = 0);
-  ~Canvas() { delwin(m_window); }
+  ~Canvas() { if (!m_isDaemon) { delwin(m_window); } }
 
-  void                refresh()                                               { wnoutrefresh(m_window); }
-  static void         refresh_std()                                           { wnoutrefresh(stdscr); }
-  void                redraw()                                                { redrawwin(m_window); }
-  static void         redraw_std()                                            { redrawwin(stdscr); }
+  void                refresh()                                               { if (!m_isDaemon) { wnoutrefresh(m_window); } }
+  static void         refresh_std()                                           { if (!m_isDaemon) { wnoutrefresh(stdscr); } }
+  void                redraw()                                                { if (!m_isDaemon) { redrawwin(m_window); } }
+  static void         redraw_std()                                            { if (!m_isDaemon) { redrawwin(stdscr); } }
 
-  void                resize(int w, int h)                                    { wresize(m_window, h, w); }
+  void                resize(int w, int h)                                    { if (!m_isDaemon) { wresize(m_window, h, w); } }
   void                resize(int x, int y, int w, int h);
 
-  static void         resize_term(int x, int y)                               { resizeterm(y, x); }
-  static void         resize_term(std::pair<int, int> dim)                    { resizeterm(dim.second, dim.first); }
+  static void         resize_term(int x, int y)                               { if (!m_isDaemon) { resizeterm(y, x); } }
+  static void         resize_term(std::pair<int, int> dim)                    { if (!m_isDaemon) { resizeterm(dim.second, dim.first); } }
 
-  unsigned int        get_x()                                                 { int x, __UNUSED y; getyx(m_window, y, x); return x; }
-  unsigned int        get_y()                                                 { int x, y; getyx(m_window, y, x); return y; }
+  unsigned int        get_x()                                                 { int x, __UNUSED y; if (!m_isDaemon) { getyx(m_window, y, x); } else { x=1; } return x; }
+  unsigned int        get_y()                                                 { int x, y; if (!m_isDaemon) { getyx(m_window, y, x); } else { y=1; } return y; }
 
-  unsigned int        width()                                                 { int x, __UNUSED y; getmaxyx(m_window, y, x); return x; }
-  unsigned int        height()                                                { int x, y; getmaxyx(m_window, y, x); return y; }
+  unsigned int        width()                                                 { int x, __UNUSED y; if (!m_isDaemon) { getmaxyx(m_window, y, x); } else { x=80; } return x; }
+  unsigned int        height()                                                { int x, y; if (!m_isDaemon) { getmaxyx(m_window, y, x); } else { y=24; } return y; }
 
-  void                move(unsigned int x, unsigned int y)                    { wmove(m_window, y, x); }
+  void                move(unsigned int x, unsigned int y)                    { if (!m_isDaemon) { wmove(m_window, y, x); } }
 
-  chtype              get_background()                                        { return getbkgd(m_window); }
-  void                set_background(chtype c)                                { return wbkgdset(m_window, c); }
+  chtype              get_background()                                        { chtype bg=0; if (!m_isDaemon) { bg=getbkgd(m_window); } return bg; }
+  void                set_background(chtype c)                                { if (!m_isDaemon) { return wbkgdset(m_window, c); } }
 
-  void                erase()                                                 { werase(m_window); }
-  static void         erase_std()                                             { werase(stdscr); }
+  void                erase()                                                 { if (!m_isDaemon) { werase(m_window); } }
+  static void         erase_std()                                             { if (!m_isDaemon) { werase(stdscr); } }
 
   void                print_border(chtype ls, chtype rs,
                                    chtype ts, chtype bs,
                                    chtype tl, chtype tr,
-                                   chtype bl, chtype br)                      { wborder(m_window, ls, rs, ts, bs, tl, tr, bl, br); }
+                                   chtype bl, chtype br)                      { if (!m_isDaemon) { wborder(m_window, ls, rs, ts, bs, tl, tr, bl, br); } }
 
   // The format string is non-const, but that will not be a problem
   // since the string shall always be a C string choosen at
@@ -90,29 +90,32 @@ public:
 
   void                print_attributes(unsigned int x, unsigned int y, const char* first, const char* last, const attributes_list* attributes);
 
-  void                print_char(const chtype ch)                                 { waddch(m_window, ch); }
-  void                print_char(unsigned int x, unsigned int y, const chtype ch) { mvwaddch(m_window, y, x, ch); }
+  void                print_char(const chtype ch)                                 { if (!m_isDaemon) { waddch(m_window, ch); } }
+  void                print_char(unsigned int x, unsigned int y, const chtype ch) { if (!m_isDaemon) { mvwaddch(m_window, y, x, ch); } }
 
-  void                set_attr(unsigned int x, unsigned int y, unsigned int n, int attr, int color) { mvwchgat(m_window, y, x, n, attr, color, NULL); }
+  void                set_attr(unsigned int x, unsigned int y, unsigned int n, int attr, int color) { if (!m_isDaemon) { mvwchgat(m_window, y, x, n, attr, color, NULL); } }
 
-  void                set_default_attributes(int attr)                            { (void)wattrset(m_window, attr); }
+  void                set_default_attributes(int attr)                            { if (!m_isDaemon) { (void)wattrset(m_window, attr); } }
 
   // Initialize stdscr.
   static void         initialize();
   static void         cleanup();
 
-  static int          get_screen_width()                                      { int x, __UNUSED y; getmaxyx(stdscr, y, x); return x; }
-  static int          get_screen_height()                                     { int x, y; getmaxyx(stdscr, y, x); return y; }
+  static int          get_screen_width()                                      { int x, __UNUSED y; if (!m_isDaemon) { getmaxyx(stdscr, y, x); } else { x=80; } return x; }
+  static int          get_screen_height()                                     { int x, y; if (!m_isDaemon) { getmaxyx(stdscr, y, x); } else { y=24;} return y; }
 
   static std::pair<int, int> term_size();
 
-  static void         do_update()                                             { doupdate(); }
+  static void         do_update()                                             { if (!m_isDaemon) { doupdate(); } }
+  
+  static bool         daemon()                                                { return m_isDaemon; }
 
 private:
   Canvas(const Canvas&);
   void operator = (const Canvas&);
 
   static bool         m_isInitialized;
+  static bool         m_isDaemon;
 
   WINDOW*             m_window;
 };
@@ -121,19 +124,23 @@ inline void
 Canvas::print(const char* str, ...) {
   va_list arglist;
 
-  va_start(arglist, str);
-  vw_printw(m_window, const_cast<char*>(str), arglist);
-  va_end(arglist);
+  if (!m_isDaemon) {
+    va_start(arglist, str);
+    vw_printw(m_window, const_cast<char*>(str), arglist);
+    va_end(arglist);
+  }
 }
 
 inline void
 Canvas::print(unsigned int x, unsigned int y, const char* str, ...) {
   va_list arglist;
 
-  va_start(arglist, str);
-  wmove(m_window, y, x);
-  vw_printw(m_window, const_cast<char*>(str), arglist);
-  va_end(arglist);
+  if (!m_isDaemon) {
+    va_start(arglist, str);
+    wmove(m_window, y, x);
+    vw_printw(m_window, const_cast<char*>(str), arglist);
+    va_end(arglist);
+  }
 }
 
 }

--- a/src/display/canvas.h
+++ b/src/display/canvas.h
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -107,7 +107,7 @@ public:
   static std::pair<int, int> term_size();
 
   static void         do_update()                                             { if (!m_isDaemon) { doupdate(); } }
-  
+
   static bool         daemon()                                                { return m_isDaemon; }
 
 private:


### PR DESCRIPTION
Implements a `system.use_daemon` variable that allows users to enable daemon mode via `system.use_daemon.set = true` in `.rtorrent.rc`

Credits to @sallyswiss for basically all of the code in #111.