### PR TITLE
Display values of 1 throttle.up in the first part of status bar

### DIFF
--- a/src/command_ui.cc
+++ b/src/command_ui.cc
@@ -584,4 +584,6 @@ initialize_command_ui() {
 
   CMD2_ANY_LIST ("elapsed.less",         std::bind(&apply_elapsed_less, std::placeholders::_2));
   CMD2_ANY_LIST ("elapsed.greater",      std::bind(&apply_elapsed_greater, std::placeholders::_2));
+
+  CMD2_VAR_STRING("ui.status.throttle_up_name", "");
 }


### PR DESCRIPTION
@rakshasa If you don't like this idea you can reject it.
It's useful especially if you modify its value dynamically, like with this:
https://github.com/chros73/rtorrent-ps_setup/blob/master/ubuntu-14.04/home/chros73/.rtorrent.rc#L221
https://github.com/chros73/rtorrent-ps_setup/blob/master/ubuntu-14.04/home/chros73/bin/getLimits.sh

----------------
Display values of 1 throttle.up in the first part of status bar.
Currently the beginning of status bar looked like this:
`[Throttle 500/1500 KB]  [Rate: 441.6/981.3 KB]`
Include the max limit of the throttle, the main upload rate and the upload rate of the throttle (in this order):
`[Throttle 500 (200)/1500 KB]  [Rate: 441.6 (190.0|51.6)/981.3 KB]`
- make the displayable throttle.up name configurable via config file: `ui.status.throttle_up_name.set`
- don't display this extra info in the following cases:

-- there isn't any throttle.up name as the config variable suggest or the given name is "NULL"
-- the throttle.up is not throttled (=0)
-- the global upload is not throttled (=0) (the throttle.up won't be taken into account in this case)