### PR TITLE
Fix scheduled sorting/filtering bug on started and stopped views in rtorrent 

### DIFF
--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -257,6 +257,10 @@ View::sort() {
 
 void
 View::filter() {
+  // Do NOT allow filter STARTED and STOPPED views: they are special
+  if (m_name == "started" || m_name == "stopped")
+    return;
+
   // Parition the list in two steps so we know which elements changed.
   iterator splitVisible  = std::stable_partition(begin_visible(),  end_visible(),  view_downloads_filter(m_filter));
   iterator splitFiltered = std::stable_partition(begin_filtered(), end_filtered(), view_downloads_filter(m_filter));


### PR DESCRIPTION
Fixes: https://github.com/rakshasa/rtorrent/issues/449
Refers to: https://github.com/chros73/rtorrent/issues/3

It works like a charm, I'm using it for 1 day now with this massive view [config](https://github.com/chros73/rtorrent-ps_setup/blob/120abeb5a562dff5555825d0a271d73d6c86dd24/ubuntu-14.04/home/chros73/.pyroscope/rtorrent-ps.rc#L71) (for rtorrent-ps).

Actually, the started view got a new meaning with this and pyroscope's idea of using  [`last_active` custom field](https://github.com/chros73/rtorrent-ps_setup/blob/120abeb5a562dff5555825d0a271d73d6c86dd24/ubuntu-14.04/home/chros73/.pyroscope/rtorrent-ps.rc#L38):
- we can [sort like this](https://github.com/chros73/rtorrent-ps_setup/blob/120abeb5a562dff5555825d0a271d73d6c86dd24/ubuntu-14.04/home/chros73/.pyroscope/rtorrent-ps.rc#L87) and it's pretty useful (like the active view) 
- and now we can add the scheduled sort for it: 

`schedule2 = sort_started,12,20,((view.sort,started))`