### PR TITLE
Fix scheduled sorting/filtering bug on started and stopped views in rtorrent

### DIFF
--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -257,6 +257,10 @@ View::sort() {
 
 void
 View::filter() {
+  // Do NOT allow filter STARTED and STOPPED views: they are special
+  if (m_name == "started" || m_name == "stopped")
+    return;
+
   // Parition the list in two steps so we know which elements changed.
   iterator splitVisible  = std::stable_partition(begin_visible(),  end_visible(),  view_downloads_filter(m_filter));
   iterator splitFiltered = std::stable_partition(begin_filtered(), end_filtered(), view_downloads_filter(m_filter));


### PR DESCRIPTION
New pull request, same content (see https://github.com/rakshasa/rtorrent/pull/451).

Fixes: https://github.com/rakshasa/rtorrent/issues/449
Refers to: https://github.com/chros73/rtorrent/issues/3

It works like a charm, I'm using it for 8 days now with this massive view [config](https://github.com/chros73/rtorrent-ps_setup/blob/master/ubuntu-14.04/home/chros73/.pyroscope/rtorrent-ps.rc#L74) (for rtorrent-ps).

Actually, the started view got a new meaning with this and pyroscope's idea of using  [`last_active` custom field](https://github.com/chros73/rtorrent-ps_setup/blob/master/ubuntu-14.04/home/chros73/.pyroscope/rtorrent-ps.rc#L41):
- we can [sort like this](https://github.com/chros73/rtorrent-ps_setup/blob/master/ubuntu-14.04/home/chros73/.pyroscope/rtorrent-ps.rc#L90) and it's pretty useful (like the active view) 
- and now we can add the scheduled sort for it: 

`schedule2 = sort_started,12,20,((view.sort,started))`

