### PR TITLE
Display values of multiple throttle.up and throttle.down in the first part of status bar

### DIFF
--- a/src/command_ui.cc
+++ b/src/command_ui.cc
@@ -777,6 +777,26 @@ apply_arith_other(const char* op, const torrent::Object::list_type& args) {
   }
 }
 
+torrent::Object
+cmd_status_throttle_names(bool up, const torrent::Object::list_type& args) {
+  if (args.size() == 0)
+    return torrent::Object();
+
+  std::vector<std::string> throttle_name_list;
+
+  for (torrent::Object::list_const_iterator itr = args.begin(), last = args.end(); itr != last; itr++) {
+    if (itr->is_string())
+      throttle_name_list.push_back(itr->as_string());
+  }
+
+  if (up)
+    control->ui()->set_status_throttle_up_names(throttle_name_list);
+  else
+    control->ui()->set_status_throttle_down_names(throttle_name_list);
+
+  return torrent::Object();
+}
+
 void
 initialize_command_ui() {
   CMD2_VAR_STRING("keys.layout", "qwerty");
@@ -823,6 +843,9 @@ initialize_command_ui() {
   CMD2_VAR_VALUE ("ui.throttle.global.step.small",  5);
   CMD2_VAR_VALUE ("ui.throttle.global.step.medium", 50);
   CMD2_VAR_VALUE ("ui.throttle.global.step.large",  500);
+
+  CMD2_ANY_LIST  ("ui.status.throttle.up.set",   std::bind(&cmd_status_throttle_names, true, std::placeholders::_2));
+  CMD2_ANY_LIST  ("ui.status.throttle.down.set", std::bind(&cmd_status_throttle_names, false, std::placeholders::_2));
 
   // TODO: Add 'option_string' for rtorrent-specific options.
   CMD2_VAR_STRING("ui.torrent_list.layout", "full");

--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -146,6 +146,35 @@ Manager::get_address_throttle(const sockaddr* addr) {
   return m_addressThrottles.get(rak::socket_address::cast_from(addr)->sa_inet()->address_h(), torrent::ThrottlePair(NULL, NULL));
 }
 
+int64_t
+Manager::retrieve_throttle_value(const torrent::Object::string_type& name, bool rate, bool up) {
+  ThrottleMap::iterator itr = throttles().find(name);
+
+  if (itr == throttles().end()) {
+    return (int64_t)-1;
+  } else {
+    torrent::Throttle* throttle = up ? itr->second.first : itr->second.second;
+
+    // check whether the actual up/down throttle exist (one of the pair can be missing)
+    if (throttle == NULL)
+      return (int64_t)-1;
+
+    int64_t throttle_max = (int64_t)throttle->max_rate();
+
+    if (rate) {
+
+      if (throttle_max > 0)
+        return (int64_t)throttle->rate()->rate();
+      else
+        return (int64_t)-1;
+
+    } else {
+      return throttle_max;
+    }
+
+  }
+}
+
 // Most of this should be possible to move out.
 void
 Manager::initialize_second() {

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -42,6 +42,7 @@
 
 #include <torrent/utils/log_buffer.h>
 #include <torrent/connection_manager.h>
+#include <torrent/object.h>
 
 #include "download_list.h"
 #include "poll_manager.h"
@@ -90,6 +91,8 @@ public:
 
   ThrottleMap&          throttles()                       { return m_throttles; }
   torrent::ThrottlePair get_throttle(const std::string& name);
+
+  int64_t             retrieve_throttle_value(const torrent::Object::string_type& name, bool rate, bool up);
 
   // Use custom throttle for the given range of IP addresses.
   void                  set_address_throttle(uint32_t begin, uint32_t end, torrent::ThrottlePair throttles);

--- a/src/display/utils.h
+++ b/src/display/utils.h
@@ -80,6 +80,9 @@ char*       print_client_version(char* first, char* last, const torrent::ClientI
 char*       print_entry_tags(char* first, char* last);
 char*       print_entry_file(char* first, char* last, const torrent::Entry& entry);
 
+char*       print_status_throttle_limit(char* first, char* last, bool up, const std::vector<std::string>& throttle_names);
+char*       print_status_throttle_rate(char* first, char* last, bool up, const std::vector<std::string>& throttle_names, const double& global_rate);
+
 char*       print_status_info(char* first, char* last);
 char*       print_status_extra(char* first, char* last);
 

--- a/src/ui/root.h
+++ b/src/ui/root.h
@@ -59,6 +59,8 @@ namespace ui {
 
 class DownloadList;
 
+typedef std::vector<std::string> ThrottleNameList;
+
 class Root {
 public:
   typedef display::WindowTitle     WTitle;
@@ -92,6 +94,12 @@ public:
   void                adjust_up_throttle(int throttle);
 
   const char*         get_throttle_keys();
+
+  ThrottleNameList&   get_status_throttle_up_names()          { return m_throttle_up_names; }
+  ThrottleNameList&   get_status_throttle_down_names()        { return m_throttle_down_names; }
+
+  void                set_status_throttle_up_names(const ThrottleNameList& throttle_list)      { m_throttle_up_names = throttle_list; }
+  void                set_status_throttle_down_names(const ThrottleNameList& throttle_list)    { m_throttle_down_names = throttle_list; }
 
   void                enable_input(const std::string& title, input::TextInput* input, ui::DownloadList::Input type);
   void                disable_input();
@@ -129,6 +137,9 @@ private:
   void                next_in_input_history(ui::DownloadList::Input type);
 
   void                reset_input_history_attributes(ui::DownloadList::Input type);
+
+  ThrottleNameList    m_throttle_up_names;
+  ThrottleNameList    m_throttle_down_names;
 };
 
 }


### PR DESCRIPTION
Display values of multiple throttle.up and throttle.down in the first part of status bar, also change name of config directive.

Currently the beginning of status bar looks like this:
`[Throttle 500/1500 KB]  [Rate: 441.6/981.3 KB]`

Include the max limit of the throttles, the main upload rate and the upload rate of the throttles (in this order); and main download rate and the download rate of the selected throttles.

Possible cases look like these:

```
[Throttle 200 / 500 KB] [Rate 107.4 / 298.6 KB]
[Throttle 200(114) / 500 KB] [Rate 107.0(1.0|105.9) / 307.6 KB]
[Throttle 200 / 500(250) KB] [Rate 124.7 / 298.2(298.2|0.0) KB]
[Throttle 200(114) / 500(250) KB] [Rate 115.9(1.7|114.2) / 333.9(333.9|0.0) KB]

[Throttle 3500(75|25) / 8000 KB] [Rate 1745.5(1635.1|85.0|25.4) /   7.3 KB]
```
- make the displayable throttle names configurable via config file: `ui.status.throttle.up.set` and `ui.status.throttle.down.set`
- original code is refactored
- throttle.up and throttle.down values can be specified simultanously (as in the last example)
- name of throttles must be specified without surrounding quotes (the setting no longer a `string` but a `list`)
  - `ui.status.throttle.up.set = slowup , tardyup`
  - `ui.status.throttle.down.set = slowup`
- limitation is that every group (there are 4 possible groups) can contain the following number of characters (it leaves space for at least 5 throttles to be displayed):
  - limit: 40 chars
  - rate: 50 chars
- don't display this extra info of a given throttle in the following cases:
  - there isn't any throttle name as the config variables suggest or the given name is "NULL"
  - the throttle is not throttled (=0)
  - the global upload/download is not throttled (=0) (the throttle won't be taken into account in this case)

Refers to: https://github.com/rakshasa/rtorrent/pull/447 , https://github.com/rakshasa/rtorrent/issues/564#issuecomment-285867371
