### PR TITLE
scale integer values with given unit, not only converted strings (closes #484)

### DIFF
--- a/src/rpc/command.cc
+++ b/src/rpc/command.cc
@@ -77,7 +77,7 @@ command_base_call_value_base(command_base* rawCommand, target_type target, const
     return command_base::_call<typename command_value_function<T>::type, T>(rawCommand, target, val);
   }
 
-  return command_base::_call<typename command_value_function<T>::type, T>(rawCommand, target, arg.as_value());
+  return command_base::_call<typename command_value_function<T>::type, T>(rawCommand, target, unit * arg.as_value());
 }
 
 template <typename T> const torrent::Object


### PR DESCRIPTION
Anything using command_base_call_value_base with a unit other than 1 ignored the scaling unit when passed an integer, i.e. "*.set_kb" interpreted a passed integer as bytes, not KiB.
