### PR TITLE
Fix type of m_ssl_verify_host variable

### DIFF
--- a/src/core/curl_stack.h
+++ b/src/core/curl_stack.h
@@ -142,7 +142,7 @@ class CurlStack : std::deque<CurlGet*> {
   std::string         m_httpCaPath;
   std::string         m_httpCaCert;
 
-  long                m_ssl_verify_host;
+  bool                m_ssl_verify_host;
   bool                m_ssl_verify_peer;
   long                m_dns_timeout;
 };


### PR DESCRIPTION
Fix type of `m_ssl_verify_host` variable:
- it's `long`
- it should be `bool`