### PR TITLE
fix segfault when viewing a magnet download in the leeching view

### DIFF
--- a/src/ui/download_list.cc
+++ b/src/ui/download_list.cc
@@ -127,11 +127,11 @@ DownloadList::set_current_view(const std::string& name) {
 // This should also do focus_next() or something.
 void
 DownloadList::unfocus_download(core::Download* d) {
-  if (current_view()->focus() >= current_view()->end_visible() || *current_view()->focus() != d)
-    return;
-
   if (m_state == DISPLAY_DOWNLOAD)
     activate_display(DISPLAY_DOWNLOAD_LIST);
+
+  if (current_view()->focus() >= current_view()->end_visible() || *current_view()->focus() != d)
+    return;
 
   current_view()->next_focus();
 }


### PR DESCRIPTION
Reproduction steps:

1. Press 9 to select the "leeching" view
1. Load-start a magnet link with backspace
1. Before the torrent file is downloaded, use the arrow keys to enter the download view for the magnet link
1. Wait for the torrent file to finish downloading
1. rtorrent segfaults

The backtrace looks like:

````
(gdb) bt
#0  0x00007ffff73f68f3 in torrent::Download::info (this=this@entry=0x963450) at download.cc:89
#1  0x00000000004deac2 in display::print_download_info_full (first=first@entry=0x7fffffffdd60 "\003", 
    last=last@entry=0x7fffffffddd3 "R\267A\005", d=0x963450) at utils.cc:137
#2  0x00000000004e87d7 in display::WindowDownloadStatusbar::redraw (this=0x992880)
    at window_download_statusbar.cc:69
#3  0x00000000004dd83d in std::function<void ()>::operator()() const (this=<optimized out>)
    at /usr/include/c++/6.2.1/functional:2136
#4  rak::priority_queue_perform (t=..., queue=0x7812a0) at ../../rak/priority_queue_default.h:98
#5  display::Manager::receive_update (this=0x781290) at manager.cc:100
#6  0x00000000004115b1 in std::function<void ()>::operator()() const (this=<optimized out>)
    at /usr/include/c++/6.2.1/functional:2136
#7  rak::priority_queue_perform (t=..., queue=<optimized out>) at ../rak/priority_queue_default.h:98
#8  client_perform () at main.cc:176
#9  0x00007ffff7451297 in std::function<void ()>::operator()() const (this=0x7a1830)
    at /usr/include/c++/6.2.1/functional:2136
#10 torrent::thread_base::event_loop (thread=0x7a1230) at thread_base.cc:139
#11 0x000000000040fc30 in main (argc=1, argv=<optimized out>) at main.cc:479
````

so the problem has to do with the management of the lifecycle of the `display::WindowDownloadStatusbar` object, which is owned by the `ui::Download` object, which is owned by the `ui::DownloadList` object. The expectation is this:

1. When a magnet is used to download a torrent file, `core::DownloadList::hash_done` will [trigger the event.download.erased event](https://github.com/rakshasa/rtorrent/blob/b90e27cc9ae4da302a709dee3310bdcfa555d01c/src/core/download_list.cc#L221)
1. which will call `ui::DownloadList::unfocus_download`
1. which will call `activate_display`
1. which will [delete the ui::Download object](https://github.com/rakshasa/rtorrent/blob/b90e27cc9ae4da302a709dee3310bdcfa555d01c/src/ui/download_list.cc#L155)

but a conditional check was blocking this between step 2 and step 3. This patch moves the check.