### PR TITLE
no // at start of expanded paths (closes #319)

### DIFF
--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -416,7 +416,7 @@ path_expand(std::vector<std::string>* paths, const std::string& pattern) {
       itr->update((r.pattern()[0] != '.') ? utils::Directory::update_hide_dot : 0);
       itr->erase(std::remove_if(itr->begin(), itr->end(), rak::on(rak::mem_ref(&utils::directory_entry::d_name), std::not1(r))), itr->end());
 
-      std::transform(itr->begin(), itr->end(), std::back_inserter(nextCache), rak::bind1st(std::ptr_fun(&path_expand_transform), itr->path() + "/"));
+      std::transform(itr->begin(), itr->end(), std::back_inserter(nextCache), rak::bind1st(std::ptr_fun(&path_expand_transform), itr->path() + (itr->path() == "/" ? "" : "/")));
     }
 
     currentCache.clear();


### PR DESCRIPTION
Tied to file starts with `//` when loaded via load.* using an absolute path.

Not any more.