### PR TITLE
Fix honoring system.file.allocate.set=1 rtorrent config setting

### DIFF
--- a/src/command_file.cc
+++ b/src/command_file.cc
@@ -105,11 +105,15 @@ initialize_command_file() {
 
   CMD2_FILE("f.is_create_queued",       std::bind(&torrent::File::is_create_queued, std::placeholders::_1));
   CMD2_FILE("f.is_resize_queued",       std::bind(&torrent::File::is_resize_queued, std::placeholders::_1));
+  CMD2_FILE("f.is_fallocatable",        std::bind(&torrent::File::is_fallocatable, std::placeholders::_1));
+  CMD2_FILE("f.is_fallocatable_file",   std::bind(&torrent::File::is_fallocatable_file, std::placeholders::_1));
 
   CMD2_FILE_VALUE_V("f.set_create_queued",   std::bind(&torrent::File::set_flags,   std::placeholders::_1, torrent::File::flag_create_queued));
   CMD2_FILE_VALUE_V("f.set_resize_queued",   std::bind(&torrent::File::set_flags,   std::placeholders::_1, torrent::File::flag_resize_queued));
+  CMD2_FILE_VALUE_V("f.set_fallocate",       std::bind(&torrent::File::set_flags,   std::placeholders::_1, torrent::File::flag_fallocate));
   CMD2_FILE_VALUE_V("f.unset_create_queued", std::bind(&torrent::File::unset_flags, std::placeholders::_1, torrent::File::flag_create_queued));
   CMD2_FILE_VALUE_V("f.unset_resize_queued", std::bind(&torrent::File::unset_flags, std::placeholders::_1, torrent::File::flag_resize_queued));
+  CMD2_FILE_VALUE_V("f.unset_fallocate",     std::bind(&torrent::File::unset_flags, std::placeholders::_1, torrent::File::flag_fallocate));
 
   CMD2_FILE  ("f.prioritize_first",         std::bind(&torrent::File::has_flags,   std::placeholders::_1, torrent::File::flag_prioritize_first));
   CMD2_FILE_V("f.prioritize_first.enable",  std::bind(&torrent::File::set_flags,   std::placeholders::_1, torrent::File::flag_prioritize_first));

--- a/src/core/download.h
+++ b/src/core/download.h
@@ -118,6 +118,8 @@ public:
   uint32_t            priority();
   void                set_priority(uint32_t p);
 
+  void                update_priorities(int flags = 0)         { m_download.update_priorities(flags); };
+
   uint32_t            resume_flags()                           { return m_resumeFlags; }
   void                set_resume_flags(uint32_t flags)         { m_resumeFlags = flags; }
 

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -120,9 +120,10 @@ DownloadList::find_hex_ptr(const char* hash) {
 Download*
 DownloadList::create(torrent::Object* obj, bool printLog) {
   torrent::Download download;
+  int fallocate = rpc::call_command_value("system.file.allocate") ? torrent::Download::open_enable_fallocate : 0;
 
   try {
-    download = torrent::download_add(obj);
+    download = torrent::download_add(obj, fallocate);
 
   } catch (torrent::local_error& e) {
     delete obj;
@@ -157,7 +158,9 @@ DownloadList::create(std::istream* str, bool printLog) {
       return NULL;
     }
 
-    download = torrent::download_add(object);
+    int fallocate = rpc::call_command_value("system.file.allocate") ? torrent::Download::open_enable_fallocate : 0;
+
+    download = torrent::download_add(object, fallocate);
 
   } catch (torrent::local_error& e) {
     delete object;
@@ -340,8 +343,6 @@ DownloadList::resume(Download* download, int flags) {
     if (download->download()->info()->is_active())
       return;
 
-    rpc::parse_command_single(rpc::make_target(download), "view.set_visible=active");
-
     // We need to make sure the flags aren't reset if someone decideds
     // to call resume() while it is hashing, etc.
     if (download->resume_flags() == ~uint32_t())
@@ -367,9 +368,6 @@ DownloadList::resume(Download* download, int flags) {
 
     // This will never actually do anything due to the above hash check.
     // open_throw(download);
-
-    rpc::call_command("d.state_changed.set", cachedTime.seconds(), rpc::make_target(download));
-    rpc::call_command("d.state_counter.set", rpc::call_command_value("d.state_counter", rpc::make_target(download)) + 1, rpc::make_target(download));
 
     if (download->is_done()) {
       torrent::Object conn_current = rpc::call_command("d.connection_seed", torrent::Object(), rpc::make_target(download));
@@ -413,12 +411,32 @@ DownloadList::resume(Download* download, int flags) {
     // Update the priority to ensure it has the correct
     // seeding/unfinished modifiers.
     download->set_priority(download->priority());
-    download->download()->start(download->resume_flags());
 
-    download->set_resume_flags(~uint32_t());
+    int openFlags = download->resume_flags();
 
-    DL_TRIGGER_EVENT(download, "event.download.resumed");
+    if (rpc::call_command_value("system.file.allocate"))
+      openFlags |= torrent::Download::open_enable_fallocate;
 
+    try {
+      download->download()->start(openFlags);
+
+      rpc::parse_command_single(rpc::make_target(download), "view.set_visible=active");
+      rpc::call_command("d.state_changed.set", cachedTime.seconds(), rpc::make_target(download));
+      rpc::call_command("d.state_counter.set", rpc::call_command_value("d.state_counter", rpc::make_target(download)) + 1, rpc::make_target(download));
+
+      download->set_resume_flags(~uint32_t());
+
+      DL_TRIGGER_EVENT(download, "event.download.resumed");
+    } catch (torrent::internal_error& e) {
+      std::string errmsg = e.what();
+
+      if (errmsg == "Tried to start an already started download.") {
+        download->set_resume_flags(~uint32_t());
+      } else if (errmsg == "Tried to start a download with not enough disk space for it.") {
+        rpc::call_command("d.stop", torrent::Object(), rpc::make_target(download));
+        control->core()->push_log_std("Not enough disk space to start download " + download->download()->info()->name());
+      }
+    }
   } catch (torrent::local_error& e) {
     lt_log_print(torrent::LOG_TORRENT_ERROR, "Could not resume download: %s", e.what());
   }

--- a/src/ui/element_file_list.cc
+++ b/src/ui/element_file_list.cc
@@ -38,6 +38,7 @@
 
 #include <rak/algorithm.h>
 #include <torrent/exceptions.h>
+#include <torrent/download.h>
 #include <torrent/data/file.h>
 #include <torrent/data/file_list.h>
 
@@ -46,6 +47,8 @@
 #include "display/text_element_string.h"
 #include "display/window_file_list.h"
 #include "input/manager.h"
+
+#include "rpc/parse_commands.h"
 
 #include "control.h"
 #include "element_file_list.h"
@@ -278,7 +281,8 @@ ElementFileList::receive_priority() {
     first++;
   }
 
-  m_download->download()->update_priorities();
+  int flags = rpc::call_command_value("system.file.allocate") ? torrent::Download::open_enable_fallocate : 0;
+  m_download->download()->update_priorities(flags);
   update_itr();
 }
 
@@ -293,7 +297,8 @@ ElementFileList::receive_change_all() {
   for (torrent::FileList::iterator itr = fl->begin(), last = fl->end(); itr != last; ++itr)
     (*itr)->set_priority(priority);
 
-  m_download->download()->update_priorities();
+  int flags = rpc::call_command_value("system.file.allocate") ? torrent::Download::open_enable_fallocate : 0;
+  m_download->download()->update_priorities(flags);
   update_itr();
 }
 


### PR DESCRIPTION
Depends on: https://github.com/rakshasa/libtorrent/pull/152
Probably clashes with: https://github.com/rakshasa/rtorrent/pull/575 (it depends on it)

With the previous patch rtorrent could be easily crashed:
- e.g. when a magnet link was loaded, started and there wasn't enough disk space for it

**Modify fixing honoring `system.file.allocate.set=1` patch:**
- do not allow to start a torrent if there's not enough disk space for it
  - notify the user about this
- modify priorities of files as well in `libtorrent`
- add 2 new file property in `libtorrent`: 
  - `is_fallocatable` : if a file has `flag_fallocate` flag
  - `is_fallocatable_file` : if a file has `flag_fallocate` and `flag_resize_queued` flags
- modify `DownloadList::create()` to take into account `system.file.allocate` setting
- modify `d.update_priorities` to be able to pass  along file flags
- refactor `DownloadList::resume()` a bit

**New commands in rtorrent:**
- `d.is_enough_diskspace` : boolean
- `d.allocatable_size_bytes` : size in bytes needed to create the download
- `f.is_fallocatable` ,  : boolean, returns true if a file has `flag_fallocate` flag
- `f.is_fallocatable_file` : boolean, returns true if a file both has `flag_fallocate` and `flag_resize_queued` flags
- `f.set_fallocate`, `f.unset_fallocate` : setters for `flag_fallocate`

**Additional fix:**
- fix `free_diskspace()` method in `libtorrent` to report back proper size even if a download is stopped

**Note:**
Unfortunately, this patch isn't complete yet, rtorrent can be still crashed:
- load a multi file torrent that is larger than free disk space but not start it
- deselect some files to be able to start download and start it
  - file allocation will be immediate
- now select some previously deselected files that won't fit on the disk
  - rtorrent will crash
