### PR TITLE
Make global throttle steps adjustable

### DIFF
--- a/src/command_ui.cc
+++ b/src/command_ui.cc
@@ -555,6 +555,10 @@ initialize_command_ui() {
   CMD2_ANY       ("ui.current_view",       std::bind(&cmd_ui_current_view));
   CMD2_ANY_STRING("ui.current_view.set",   std::bind(&cmd_ui_set_view, std::placeholders::_2));
 
+  CMD2_VAR_VALUE ("ui.throttle.global.step.small",  5);
+  CMD2_VAR_VALUE ("ui.throttle.global.step.medium", 50);
+  CMD2_VAR_VALUE ("ui.throttle.global.step.large",  500);
+
   // TODO: Add 'option_string' for rtorrent-specific options.
   CMD2_VAR_STRING("ui.torrent_list.layout", "full");
 

--- a/src/ui/download.cc
+++ b/src/ui/download.cc
@@ -54,6 +54,7 @@
 #include "display/window_download_statusbar.h"
 
 #include "display/text_element_string.h"
+#include "rpc/parse_commands.h"
 
 #include "control.h"
 #include "download.h"
@@ -395,20 +396,20 @@ Download::bind_keys() {
 
   const char* keys = control->ui()->get_throttle_keys();
 
-  m_bindings[keys[ 0]] = std::bind(&Download::adjust_up_throttle, this, 1);
-  m_bindings[keys[ 1]] = std::bind(&Download::adjust_up_throttle, this, -1);
-  m_bindings[keys[ 2]] = std::bind(&Download::adjust_down_throttle, this, 1);
-  m_bindings[keys[ 3]] = std::bind(&Download::adjust_down_throttle, this, -1);
+  m_bindings[keys[ 0]] = std::bind(&Download::adjust_up_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.small"));
+  m_bindings[keys[ 1]] = std::bind(&Download::adjust_up_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.small"));
+  m_bindings[keys[ 2]] = std::bind(&Download::adjust_down_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.small"));
+  m_bindings[keys[ 3]] = std::bind(&Download::adjust_down_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.small"));
 
-  m_bindings[keys[ 4]] = std::bind(&Download::adjust_up_throttle, this, 5);
-  m_bindings[keys[ 5]] = std::bind(&Download::adjust_up_throttle, this, -5);
-  m_bindings[keys[ 6]] = std::bind(&Download::adjust_down_throttle, this, 5);
-  m_bindings[keys[ 7]] = std::bind(&Download::adjust_down_throttle, this, -5);
+  m_bindings[keys[ 4]] = std::bind(&Download::adjust_up_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.medium"));
+  m_bindings[keys[ 5]] = std::bind(&Download::adjust_up_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.medium"));
+  m_bindings[keys[ 6]] = std::bind(&Download::adjust_down_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.medium"));
+  m_bindings[keys[ 7]] = std::bind(&Download::adjust_down_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.medium"));
 
-  m_bindings[keys[ 8]] = std::bind(&Download::adjust_up_throttle, this, 50);
-  m_bindings[keys[ 9]] = std::bind(&Download::adjust_up_throttle, this, -50);
-  m_bindings[keys[10]] = std::bind(&Download::adjust_down_throttle, this, 50);
-  m_bindings[keys[11]] = std::bind(&Download::adjust_down_throttle, this, -50);
+  m_bindings[keys[ 8]] = std::bind(&Download::adjust_up_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.large"));
+  m_bindings[keys[ 9]] = std::bind(&Download::adjust_up_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.large"));
+  m_bindings[keys[10]] = std::bind(&Download::adjust_down_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.large"));
+  m_bindings[keys[11]] = std::bind(&Download::adjust_down_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.large"));
 }
 
 }

--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -140,20 +140,20 @@ Root::setup_keys() {
 
   const char* keys = get_throttle_keys();
 
-  m_bindings[keys[ 0]]      = std::bind(&Root::adjust_up_throttle, this, 1);
-  m_bindings[keys[ 1]]      = std::bind(&Root::adjust_up_throttle, this, -1);
-  m_bindings[keys[ 2]]      = std::bind(&Root::adjust_down_throttle, this, 1);
-  m_bindings[keys[ 3]]      = std::bind(&Root::adjust_down_throttle, this, -1);
+  m_bindings[keys[ 0]]      = std::bind(&Root::adjust_up_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.small"));
+  m_bindings[keys[ 1]]      = std::bind(&Root::adjust_up_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.small"));
+  m_bindings[keys[ 2]]      = std::bind(&Root::adjust_down_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.small"));
+  m_bindings[keys[ 3]]      = std::bind(&Root::adjust_down_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.small"));
 
-  m_bindings[keys[ 4]]      = std::bind(&Root::adjust_up_throttle, this, 5);
-  m_bindings[keys[ 5]]      = std::bind(&Root::adjust_up_throttle, this, -5);
-  m_bindings[keys[ 6]]      = std::bind(&Root::adjust_down_throttle, this, 5);
-  m_bindings[keys[ 7]]      = std::bind(&Root::adjust_down_throttle, this, -5);
+  m_bindings[keys[ 4]]      = std::bind(&Root::adjust_up_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.medium"));
+  m_bindings[keys[ 5]]      = std::bind(&Root::adjust_up_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.medium"));
+  m_bindings[keys[ 6]]      = std::bind(&Root::adjust_down_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.medium"));
+  m_bindings[keys[ 7]]      = std::bind(&Root::adjust_down_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.medium"));
 
-  m_bindings[keys[ 8]]      = std::bind(&Root::adjust_up_throttle, this, 50);
-  m_bindings[keys[ 9]]      = std::bind(&Root::adjust_up_throttle, this, -50);
-  m_bindings[keys[10]]      = std::bind(&Root::adjust_down_throttle, this, 50);
-  m_bindings[keys[11]]      = std::bind(&Root::adjust_down_throttle, this, -50);
+  m_bindings[keys[ 8]]      = std::bind(&Root::adjust_up_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.large"));
+  m_bindings[keys[ 9]]      = std::bind(&Root::adjust_up_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.large"));
+  m_bindings[keys[10]]      = std::bind(&Root::adjust_down_throttle, this, (int) rpc::call_command_value("ui.throttle.global.step.large"));
+  m_bindings[keys[11]]      = std::bind(&Root::adjust_down_throttle, this, (int) -rpc::call_command_value("ui.throttle.global.step.large"));
 
   m_bindings['\x0C']        = std::bind(&display::Manager::force_redraw, m_control->display()); // ^L
   m_bindings['\x11']        = std::bind(&Control::receive_normal_shutdown, m_control); // ^Q


### PR DESCRIPTION
Make [global throttle steps](https://github.com/rakshasa/rtorrent/wiki/User-Guide#throttling) adjustable (original patch is by @pyroscope).
Default values:
```
ui.throttle.global.step.small.set  =   5
ui.throttle.global.step.medium.set =  50
ui.throttle.global.step.large.set  = 500
```

Closes: #316 (increase/adjust throttle steps)