### PR TITLE
Modify directory.watch.added and add directory.watch.removed command

### DIFF
--- a/src/command_events.cc
+++ b/src/command_events.cc
@@ -308,24 +308,88 @@ d_multicall(const torrent::Object::list_type& args) {
 }
 
 static void
-call_watch_command(const std::string& command, const std::string& path) {
-  rpc::commands.call_catch(command.c_str(), rpc::make_target(), path);
+call_watch_command_added(const core::Manager::command_list_type& args, const std::string& path) {
+  if (args.size() < 1)
+    throw torrent::input_error("Too few arguments.");
+
+  std::string rpc_command_str;
+  core::Manager::command_list_type::const_iterator argsItr = args.begin();
+
+  std::string command = *argsItr;
+
+  rpc_command_str = command + (*command.rbegin() != '=' ? "=" : "") + path;
+
+  while (++argsItr != args.end())
+    rpc_command_str += ", \"" + *argsItr + "\"";
+
+  rpc::parse_command_single_std(rpc_command_str);
 }
 
 torrent::Object
 directory_watch_added(const torrent::Object::list_type& args) {
-  if (args.size() != 2)
+  if (args.size() < 2)
     throw torrent::input_error("Too few arguments.");
-
-  const std::string& path = args.front().as_string();
-  const std::string& command = args.back().as_string();
 
   if (!control->directory_events()->open())
     throw torrent::input_error("Could not open inotify:" + std::string(rak::error_number::current().c_str()));
 
-  control->directory_events()->notify_on(path.c_str(),
+  core::Manager::command_list_type commands;
+  torrent::Object::list_const_iterator argsItr = args.begin();
+
+  const std::string& path = argsItr->as_string();
+
+  while (++argsItr != args.end())
+    commands.push_back(argsItr->as_string());
+
+  control->directory_events()->notify_on(path,
                                          torrent::directory_events::flag_on_added | torrent::directory_events::flag_on_updated,
-                                         std::bind(&call_watch_command, command, std::placeholders::_1));
+                                         std::bind(&call_watch_command_added, commands, std::placeholders::_1));
+  return torrent::Object();
+}
+
+static void
+call_watch_command_removed(const std::string& command, const std::string& path) {
+  if (command != "d.stop" && command != "d.close" && command != "d.erase")
+    return;
+
+  for (core::DownloadList::iterator itr = control->core()->download_list()->begin(); itr != control->core()->download_list()->end(); ++itr) {
+    const std::string& tiedToFile = rpc::call_command_string("d.tied_to_file", rpc::make_target(*itr));
+
+    if (!tiedToFile.empty() && rak::path_expand(path) == rak::path_expand(tiedToFile)) {
+
+      if (command == "d.stop" && rpc::call_command_value("d.state", rpc::make_target(*itr)) != 0) {
+        rpc::parse_command_single(rpc::make_target(*itr), "d.try_stop=");
+      } else if (command == "d.close" && rpc::call_command_value("d.ignore_commands", rpc::make_target(*itr)) == 0) {
+        rpc::parse_command_single(rpc::make_target(*itr), "d.try_close=");
+      } else if (command == "d.erase") {
+        // Need to clear tied_to_file so it doesn't try to delete it.
+        rpc::call_command("d.tied_to_file.set", std::string(), rpc::make_target(*itr));
+        control->core()->download_list()->erase(itr);
+      }
+
+      break;
+    }
+  }
+}
+
+torrent::Object
+directory_watch_removed(const torrent::Object::list_type& args) {
+  if (args.size() < 2)
+    throw torrent::input_error("Too few arguments.");
+
+  torrent::Object::list_const_iterator argsItr = args.begin();
+  std::string command = argsItr->as_string();
+
+  if (command != "d.stop" && command != "d.close" && command != "d.erase")
+    throw torrent::input_error("directory.watch.removed command only supports d.stop , d.close , d.erase commands.");
+
+  if (!control->directory_events()->open())
+    throw torrent::input_error("Could not open inotify:" + std::string(rak::error_number::current().c_str()));
+
+  while (++argsItr != args.end())
+    control->directory_events()->notify_on(argsItr->as_string(),
+                                         torrent::directory_events::flag_on_removed,
+                                         std::bind(&call_watch_command_removed, command, std::placeholders::_1));
   return torrent::Object();
 }
 
@@ -333,10 +397,10 @@ void
 initialize_command_events() {
   CMD2_ANY_STRING  ("on_ratio",        std::bind(&apply_on_ratio, std::placeholders::_2));
 
-  CMD2_ANY         ("start_tied",      std::bind(&apply_start_tied));
-  CMD2_ANY         ("stop_untied",     std::bind(&apply_stop_untied));
-  CMD2_ANY         ("close_untied",    std::bind(&apply_close_untied));
-  CMD2_ANY         ("remove_untied",   std::bind(&apply_remove_untied));
+  CMD2_ANY         ("tied.start",      std::bind(&apply_start_tied));
+  CMD2_ANY         ("untied.stop",     std::bind(&apply_stop_untied));
+  CMD2_ANY         ("untied.close",    std::bind(&apply_close_untied));
+  CMD2_ANY         ("untied.remove",   std::bind(&apply_remove_untied));
 
   CMD2_ANY_LIST    ("schedule2",        std::bind(&apply_schedule, std::placeholders::_2));
   CMD2_ANY_STRING_V("schedule_remove2", std::bind(&rpc::CommandScheduler::erase_str, control->command_scheduler(), std::placeholders::_2));
@@ -360,5 +424,6 @@ initialize_command_events() {
   CMD2_ANY_LIST    ("download_list",       std::bind(&apply_download_list, std::placeholders::_2));
   CMD2_ANY_LIST    ("d.multicall2",        std::bind(&d_multicall, std::placeholders::_2));
 
-  CMD2_ANY_LIST    ("directory.watch.added", std::bind(&directory_watch_added, std::placeholders::_2));
+  CMD2_ANY_LIST    ("directory.watch.added",   std::bind(&directory_watch_added, std::placeholders::_2));
+  CMD2_ANY_LIST    ("directory.watch.removed", std::bind(&directory_watch_removed, std::placeholders::_2));
 }

--- a/src/command_events.cc
+++ b/src/command_events.cc
@@ -317,10 +317,11 @@ call_watch_command_added(const core::Manager::command_list_type& args, const std
 
   std::string command = *argsItr;
 
-  rpc_command_str = command + (*command.rbegin() != '=' ? "=" : "") + path;
+  // Include path in quotes, it can have spaces.
+  rpc_command_str = command + (*command.rbegin() != '=' ? "=" : "") + "\"" + path + "\"";
 
   while (++argsItr != args.end())
-    rpc_command_str += ", \"" + *argsItr + "\"";
+    rpc_command_str += ",\"" + *argsItr + "\"";
 
   rpc::parse_command_single_std(rpc_command_str);
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -419,6 +419,11 @@ main(int argc, char** argv) {
 
     CMD2_REDIRECT        ("torrent_list_layout", "ui.torrent_list.layout.set");
 
+    CMD2_REDIRECT_GENERIC("start_tied",    "tied.start");
+    CMD2_REDIRECT_GENERIC("stop_untied",   "untied.stop");
+    CMD2_REDIRECT_GENERIC("close_untied",  "untied.close");
+    CMD2_REDIRECT_GENERIC("remove_untied", "untied.remove");
+
     // Deprecated commands. Don't use these anymore.
 
     if (rpc::call_command_value("method.use_intermediate") == 1) {


### PR DESCRIPTION
One of the advantages of using "inotify" to load and remove downloads by torrent meta files is the reduced  file system IO (apart from it's instant).

Refers to: https://github.com/rakshasa/rtorrent/issues/374

**A. Modify `directory.watch.added`**
Allow it to accept multiple commands (as `load.*` commands).
There are multiple ways to achieve this but since there's no "shortcut" (the directory (that is watched) for inotify has to be separated), the final command (that is called on an "add" event) is reconstructed as a line of config.
- 1st param: the directory that will be watched
- 2nd param: the name of the main command that will be called if an "add" event is triggered (`load.*` commands)
- rest of the params: extra commands that will be passed as arguments to the above specified main command
  - if an extra command include commas (`,` parameter separator) then it needs to be included inside quotes (`"`)
```ini
directory.watch.added = (cat,(cfg.dir.meta_downl),unsafe/),   load.start,  "d.attribs.set=unsafe,,1", print=loadedunsafe
```


**B. Add `directory.watch.removed`**
Similarly to loading event, add ability to handle removing events of meta files as `*_untied` commands:
- `*_untied` commands can't deal with a download individually: they go through and check all the downloads (they can generate lot of IO, especially if they are used with `schedule` command)
- `directory.watch.removed` handles this individually

Since it doesn't need any additional commands, it accepts multiple directories as parameters.
- 1st param: the command to call when a meta file is removed, only 3 commands are supported
  - `d.stop`, `d.close`, `d.erase` 
- rest of the params: comma separated list of the directories that will be watched
```ini
directory.watch.removed = d.erase, (cat,(cfg.dir.meta_compl),various/), (cat,(cfg.dir.meta_compl),unsafe/)
```


**C. Rename `*tied` commands**
Rename untied commands and add redirects for the new names to preserve compatibility:
- `start_tied` -> `tied.start`
- `stop_untied` -> `untied.stop`
- `close_untied` -> `untied.close`
- `remove_untied` -> `untied.remove`


**D. Limitations**
- a given directory can only be specified once with either `directory.watch.added` or `directory.watch.removed`
- torrent meta files that are "added" / "removed" into/from watched directories will be discarded if rtorrent wasn't run at the time of adding / removing
  - it's a good idea to run the normal scheduled "watch" command once after rtorrent is started
- probably it won't work well with network file systems (NFS, Samba, etc.)


**E. `directory.watch.*` commands in action**
Let's assume the following:
- we have multiple watch directories with which we want to use different properties for downloads with a parameterised command (like this [d.attribs.set](https://github.com/chros73/rtorrent-ps_setup/blob/develop/ubuntu-14.04/home/chros73/.rtorrent.rc#L53))
- we want to provide the ability of switching inotify support for users in config
- we also want to watch directories for removed metafiles
  - the meta files is moved by rtorrent (internally) when a download is finished

```ini
# Defining directory constants
method.insert = cfg.dir.main,       string|const|private, (cat,"/mnt/Torrents/")
method.insert = cfg.dir.sub,        string|const|private, (cat,(cfg.dir.main),".rtorrent/")
method.insert = cfg.dir.meta_downl, string|const|private, (cat,(cfg.dir.sub),".downloading/")
method.insert = cfg.dir.meta_compl, string|const|private, (cat,(cfg.dir.sub),".completed/")

# Whether to use inotify for loading/removing torrent (meta) files from watch directories
method.insert = cfg.inotify.use, value|const|private, 1

# Whatch dir definitions for loading metafiles using inotify
branch = ((cfg.inotify.use)), ((directory.watch.added, (cat,(cfg.dir.meta_downl),rotating/), load.start,  "d.attribs.set=rotating,1,1"))
branch = ((cfg.inotify.use)), ((directory.watch.added, (cat,(cfg.dir.meta_downl),fullseed/), load.start,  "d.attribs.set=fullseed,1,"))
branch = ((cfg.inotify.use)), ((directory.watch.added, (cat,(cfg.dir.meta_downl),unsafe/),   load.start,  "d.attribs.set=unsafe,,1"))
branch = ((cfg.inotify.use)), ((directory.watch.added, (cat,(cfg.dir.meta_downl),various/),  load.start,  "d.attribs.set=various,,"))
branch = ((cfg.inotify.use)), ((directory.watch.added, (cat,(cfg.dir.meta_downl),load/),     load.normal, "d.attribs.set=unsafe,,1"))

# Fire up only once (after rtorrent is started) the normal scheluded load watch dirs as well even if inotify is used: load added metafiles when rtorrent hasn't been run
branch = ((cfg.inotify.use)), ((schedule2, watch_dir_1,  85, 0, ((load.start, (cat,(cfg.dir.meta_downl),rotating/*.torrent), "d.attribs.set=rotating,1,1"))))
branch = ((cfg.inotify.use)), ((schedule2, watch_dir_2,  86, 0, ((load.start, (cat,(cfg.dir.meta_downl),fullseed/*.torrent), "d.attribs.set=fullseed,1,"))))
branch = ((cfg.inotify.use)), ((schedule2, watch_dir_3,  87, 0, ((load.start, (cat,(cfg.dir.meta_downl),unsafe/*.torrent),   "d.attribs.set=unsafe,,1"))))
branch = ((cfg.inotify.use)), ((schedule2, watch_dir_4,  88, 0, ((load.start, (cat,(cfg.dir.meta_downl),various/*.torrent),  "d.attribs.set=various,,"))))
branch = ((cfg.inotify.use)), ((schedule2, watch_dir_5,  89, 0, ((load.normal,(cat,(cfg.dir.meta_downl),load/*.torrent),     "d.attribs.set=unsafe,,1"))))

# Whatch dir definitions for removing metafiles using inotify
branch = ((cfg.inotify.use)), ((directory.watch.removed, d.erase, (cat,(cfg.dir.meta_compl),various/), (cat,(cfg.dir.meta_compl),unsafe/), (cat,(cfg.dir.meta_compl),rotating/), (cat,(cfg.dir.meta_compl),fullseed/), (cat,(cfg.dir.meta_compl),load/)))

# Whatch dir definitions for loading metafiles NOT using inotify
branch = ((not, (cfg.inotify.use))), ((schedule2, watch_dir_1,  5, 10, ((load.start, (cat,(cfg.dir.meta_downl),rotating/*.torrent), "d.attribs.set=rotating,1,1"))))
branch = ((not, (cfg.inotify.use))), ((schedule2, watch_dir_2,  6, 10, ((load.start, (cat,(cfg.dir.meta_downl),fullseed/*.torrent), "d.attribs.set=fullseed,1,"))))
branch = ((not, (cfg.inotify.use))), ((schedule2, watch_dir_3,  7, 10, ((load.start, (cat,(cfg.dir.meta_downl),unsafe/*.torrent),   "d.attribs.set=unsafe,,1"))))
branch = ((not, (cfg.inotify.use))), ((schedule2, watch_dir_4,  8, 10, ((load.start, (cat,(cfg.dir.meta_downl),various/*.torrent),  "d.attribs.set=various,,"))))
branch = ((not, (cfg.inotify.use))), ((schedule2, watch_dir_5,  9, 10, ((load.normal,(cat,(cfg.dir.meta_downl),load/*.torrent),     "d.attribs.set=unsafe,,1"))))

# Removes torrents from client when its metafile (torrent file) has been deleted manually or by a script. If inotify isn't used: Run it every 5 seconds, otherwise run only once after rtorrent is started.
branch = ((cfg.inotify.use)), ((schedule2, untied_torrents, 99, 0, ((untied.remove)))), ((schedule2, untied_torrents, 8, 10, ((untied.remove))))
```