### PR TITLE
add d.custom.if_z + d.custom.keys + d.custom.items

### DIFF
--- a/src/command_download.cc
+++ b/src/command_download.cc
@@ -275,6 +275,40 @@ retrieve_d_custom_throw(core::Download* download, const std::string& key) {
 }
 
 torrent::Object
+retrieve_d_custom_if_z(core::Download* download, const torrent::Object::list_type& args) {
+  torrent::Object::list_const_iterator itr = args.begin();
+  if (itr == args.end())
+    throw torrent::bencode_error("d.custom.if_z: Missing key argument.");
+  const std::string& key = (itr++)->as_string();
+  if (key.empty())
+    throw torrent::bencode_error("d.custom.if_z: Empty key argument.");
+  if (itr == args.end())
+    throw torrent::bencode_error("d.custom.if_z: Missing default argument.");
+
+  try {
+    return download->bencode()->get_key("rtorrent").get_key("custom").get_key_string(key);
+  } catch (torrent::bencode_error& e) {
+    return itr->as_string();
+  }
+}
+
+torrent::Object
+retrieve_d_custom_map(core::Download* download, bool keys_only, const torrent::Object::list_type& args) {
+  if (args.begin() != args.end())
+    throw torrent::bencode_error("d.custom.keys/items takes no arguments.");
+
+  torrent::Object result = keys_only ? torrent::Object::create_list() : torrent::Object::create_map();
+  torrent::Object::map_type& entries = download->bencode()->get_key("rtorrent").get_key("custom").as_map();
+
+  for (torrent::Object::map_type::const_iterator itr = entries.begin(), last = entries.end(); itr != last; itr++) {
+    if (keys_only) result.as_list().push_back(itr->first);
+    else           result.as_map()[itr->first] = itr->second;
+  }
+
+  return result;
+}
+
+torrent::Object
 retrieve_d_bitfield(core::Download* download) {
   const torrent::Bitfield* bitField = download->download()->file_list()->bitfield();
 
@@ -710,6 +744,9 @@ initialize_command_download() {
   CMD2_DL_STRING("d.custom",       std::bind(&retrieve_d_custom, std::placeholders::_1, std::placeholders::_2));
   CMD2_DL_STRING("d.custom_throw", std::bind(&retrieve_d_custom_throw, std::placeholders::_1, std::placeholders::_2));
   CMD2_DL_LIST  ("d.custom.set",   std::bind(&apply_d_custom, std::placeholders::_1, std::placeholders::_2));
+  CMD2_DL_LIST  ("d.custom.if_z",  std::bind(&retrieve_d_custom_if_z, std::placeholders::_1, std::placeholders::_2));
+  CMD2_DL_LIST  ("d.custom.keys",  std::bind(&retrieve_d_custom_map, std::placeholders::_1, true, std::placeholders::_2));
+  CMD2_DL_LIST  ("d.custom.items", std::bind(&retrieve_d_custom_map, std::placeholders::_1, false, std::placeholders::_2));
 
   CMD2_DL_VAR_STRING_PUBLIC("d.custom1", "rtorrent", "custom1");
   CMD2_DL_VAR_STRING_PUBLIC("d.custom2", "rtorrent", "custom2");


### PR DESCRIPTION
`d.custom.if_z` allows to cleanly build fallback chains 
(use other customs or static values if not defined),
without resorting to complex if constructs.

`d.custom.keys` and `d.custom.items` is useful for debugging,
but might have other use-cases people will discover (e.g. a panel
with all the customs in an external client).


## d.custom.if_z

    d.custom.if_z = ‹hash›, string ‹key›, string ‹default› ≫ string ‹value›

Just like `d.custom`, but returns the `‹default›` value if the `‹key›` does not exist.


## d.custom.keys

    d.custom.keys = ‹hash› ≫ list of string ‹defined keys›

Returns a list of custom keys that are defined for an item.

Example:

    $ rtxmlrpc --repr d.custom.keys $(rtxmlrpc download_list | head -n1) | tr -d \\n
    [… 'tm_downloaded', 'tm_last_scrape', 'tm_loaded', 'tm_started']


## d.custom.items

    d.custom.items = ‹hash› ≫ map of key / value strings ‹defined items›

Returns keys and their associated values, for all named custom values of an item.

Example:

    $ rtxmlrpc --repr d.custom.items $(rtxmlrpc download_list | head -n1)
    {…
     'tm_downloaded': '1522406424',
     'tm_last_scrape': '1527931151',
     'tm_loaded': '1522406432',
     'tm_started': '1522406432'}
