### PR TITLE
add 'd.multicall.filtered' command

### DIFF
--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -296,6 +296,16 @@ View::filter() {
 }
 
 void
+View::filter_by(const torrent::Object& condition, View::base_type& result)
+{
+  // std::copy_if(begin_visible(), end_visible(), result.begin(), view_downloads_filter(condition));
+  view_downloads_filter matches = view_downloads_filter(condition);
+  for (iterator itr = begin_visible(); itr != end_visible(); ++itr)
+    if (matches(*itr))
+      result.push_back(*itr);
+}
+
+void
 View::filter_download(core::Download* download) {
   iterator itr = std::find(base_type::begin(), base_type::end(), download);
 

--- a/src/core/view.h
+++ b/src/core/view.h
@@ -120,6 +120,7 @@ public:
 
   // Need to explicity trigger filtering.
   void                filter();
+  void                filter_by(const torrent::Object& condition, base_type& result);
   void                filter_download(core::Download* download);
 
   const torrent::Object& get_filter() const { return m_filter; }


### PR DESCRIPTION
## d.multicall.filtered

Makes a boost to performance of external clients possible (by returning way less data via xmlrpc, based on filter criteria), supporting the new daemon mode better…

    $ rtxmlrpc --repr d.multicall.filtered 'default' 'd.ignore_commands=' d.hash= d.name=
    [['4F…8A', 'name']]
