### PR TITLE
add 'event.view.hide/show' commands / events

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -249,6 +249,9 @@ main(int argc, char** argv) {
 
     rpc::parse_command_multiple
       (rpc::make_target(),
+       "method.insert = event.view.hide,multi|rlookup|static\n"
+       "method.insert = event.view.show,multi|rlookup|static\n"
+
        "method.insert = event.download.inserted,multi|rlookup|static\n"
        "method.insert = event.download.inserted_new,multi|rlookup|static\n"
        "method.insert = event.download.inserted_session,multi|rlookup|static\n"

--- a/src/ui/element_download_list.cc
+++ b/src/ui/element_download_list.cc
@@ -220,7 +220,14 @@ ElementDownloadList::receive_change_view(const std::string& name) {
     return;
   }
 
+  std::string old_name = view() ? view()->name() : "";
+  if (!old_name.empty())
+    rpc::commands.call_catch("event.view.hide", rpc::make_target(), name,
+                             "View hide event action failed: ");
   set_view(*itr);
+  if (!old_name.empty())
+    rpc::commands.call_catch("event.view.show", rpc::make_target(), old_name,
+                             "View show event action failed: ");
 }
 
 void


### PR DESCRIPTION
Can be used to e.g. populate / update a view on demand – if used seldom, there is no need to update it on a schedule, and also it's more up-to-date this way.

Full docs @ https://rtorrent-docs.readthedocs.io/en/latest/cmd-ref.html#term-event-view-hide