### PR TITLE
add 'compare' command / operator

### DIFF
--- a/src/command_ui.cc
+++ b/src/command_ui.cc
@@ -284,6 +284,56 @@ torrent::Object apply_equal(rpc::target_type target, const torrent::Object::list
 }
 
 torrent::Object
+apply_compare(rpc::target_type target, const torrent::Object::list_type& args) {
+  if (!rpc::is_target_pair(target))
+    throw torrent::input_error("Can only compare a target pair.");
+
+  if (args.size() < 2)
+    throw torrent::input_error("Need at least order and one field.");
+
+  torrent::Object::list_const_iterator itr = args.begin();
+  std::string order = (itr++)->as_string();
+  const char* current = order.c_str();
+
+  torrent::Object result1;
+  torrent::Object result2;
+
+  for (torrent::Object::list_const_iterator last = args.end(); itr != last; itr++) {
+    std::string field = itr->as_string();
+    result1 = rpc::parse_command_single(rpc::get_target_left(target), field);
+    result2 = rpc::parse_command_single(rpc::get_target_right(target), field);
+
+    if (result1.type() != result2.type())
+      throw torrent::input_error(std::string("Type mismatch in compare of ") + field);
+
+    bool descending = *current == 'd' || *current == 'D' || *current == '-';
+    if (*current) {
+      if (!descending && !(*current == 'a' || *current == 'A' || *current == '+'))
+        throw torrent::input_error(std::string("Bad order '") + *current + "' in " + order);
+      ++current;
+    }
+
+    switch (result1.type()) {
+      case torrent::Object::TYPE_VALUE:
+        if (result1.as_value() != result2.as_value())
+          return (int64_t) (descending ^ (result1.as_value() < result2.as_value()));
+        break;
+
+      case torrent::Object::TYPE_STRING:
+        if (result1.as_string() != result2.as_string())
+          return (int64_t) (descending ^ (result1.as_string() < result2.as_string()));
+        break;
+
+      default:
+        break; // treat unknown types as equal
+    }
+  }
+
+  // if all else is equal, ensure stable sort order based on memory location
+  return (int64_t) (target.second < target.third);
+}
+
+torrent::Object
 apply_to_time(const torrent::Object& rawArgs, int flags) {
   std::tm *u;
   time_t t = (uint64_t)rawArgs.as_value();
@@ -697,6 +747,7 @@ initialize_command_ui() {
   CMD2_ANY_LIST("less",    &apply_less);
   CMD2_ANY_LIST("greater", &apply_greater);
   CMD2_ANY_LIST("equal",   &apply_equal);
+  CMD2_ANY_LIST("compare", &apply_compare);
 
   CMD2_ANY_VALUE("convert.gm_time",      std::bind(&apply_to_time, std::placeholders::_2, 0));
   CMD2_ANY_VALUE("convert.gm_date",      std::bind(&apply_to_time, std::placeholders::_2, 0x2));


### PR DESCRIPTION
`compare = <order>, <sort_key1>=[, ...]`

Compares two items like `less=` or `greater=`, but allows to compare by several different sort criteria, and ascending or descending order per given field.

The first parameter is a string of order indicators, either `aA+` for ascending or `dD-` for descending. The default, i.e. when there's more fields than indicators, is ascending. Field types other than value or string are treated as equal (or in other words, they're ignored).

If all fields are equal, then items are ordered in a random, but stable fashion.

Configuration example:

    # VIEW: Show active and incomplete torrents (in view #9) and update every 20 seconds
    #       Items are grouped into complete, incomplete, and queued, in that order.
    #       Within each group, they're sorted by upload and then download speed.
    view.sort_current = active,"compare=----,d.is_open=,d.complete=,d.up.rate=,d.down.rate="
    schedule = filter_active,12,20,"view.filter = active,\"or={d.up.rate=,d.down.rate=,not=$d.complete=}\" ;view.sort=active"
