### PR TITLE
Use AC_COMPILE instead of AC_RUN to check for execinfo.h

### DIFF
--- a/scripts/common.m4
+++ b/scripts/common.m4
@@ -153,7 +153,7 @@ dnl   Need to fix this so that it uses the stuff defined by the system.
 AC_DEFUN([TORRENT_CHECK_EXECINFO], [
   AC_MSG_CHECKING(for execinfo.h)
 
-  AC_RUN_IFELSE([AC_LANG_SOURCE([
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([
       #include <execinfo.h>
       int main() { backtrace((void**)0, 0); backtrace_symbols((char**)0, 0); return 0;}
       ])],


### PR DESCRIPTION
This way enables cross compiling, since we don't need to run anything during the configure script.

Same as rakshasa/libtorrent#175 - any suggestions as to improvements are welcome.