### PR TITLE
Add 'event.system.startup_done/shutdown' commands/events

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -168,6 +168,8 @@ Control::is_shutdown_completed() {
 
 void
 Control::handle_shutdown() {
+  rpc::commands.call_catch("event.system.shutdown", rpc::make_target(), "shutdown", "System shutdown event action failed: ");
+
   if (!m_shutdownQuick) {
     // Temporary hack:
     if (worker_thread->is_active())

--- a/src/main.cc
+++ b/src/main.cc
@@ -252,6 +252,9 @@ main(int argc, char** argv) {
        "method.insert = event.view.hide,multi|rlookup|static\n"
        "method.insert = event.view.show,multi|rlookup|static\n"
 
+       "method.insert = event.system.startup_done,multi|rlookup|static\n"
+       "method.insert = event.system.shutdown,multi|rlookup|static\n"
+
        "method.insert = event.download.inserted,multi|rlookup|static\n"
        "method.insert = event.download.inserted_new,multi|rlookup|static\n"
        "method.insert = event.download.inserted_session,multi|rlookup|static\n"
@@ -479,6 +482,8 @@ main(int argc, char** argv) {
     control->display()->receive_update();
 
     worker_thread->start_thread();
+
+    rpc::commands.call_catch("event.system.startup_done", rpc::make_target(), "startup_done", "System startup_done event action failed: ");
 
     torrent::thread_base::event_loop(torrent::main_thread());
 


### PR DESCRIPTION
**A. Add `event.system.*` commands:**
- `event.system.startup_done` : triggered when startup is done
  - e.g. after loading session files
  - it doesn't mean that processing all the downloads are finished at this point (e.g. `event.download.resumed` starts after this event)
- `event.system.shutdown` : triggered when shutdown is started

**B. Usage examples:**
```ini
# COMMAND/EVENT: Return startup time (can be used to calculate uptime)
method.insert  = system.startup_time, value, 0
method.set_key = event.system.startup_done, !!set_startup_time, {(branch, ((not,((system.startup_time)))), ((system.startup_time.set, (system.time))) )}
# Display startup time at startup
method.set_key = event.system.startup_done, ~log,  ((print, "Startup time: ", ((system.startup_time)) ))
# Prevent command to fire up on 'event.view.*' event during startup
method.set_key = event.view.show, ~print_name,  {(branch, ((system.startup_time)), ((print, ((ui.current_view)))) )}

# COMMAND/EVENT: Return shutdown time
method.insert  = system.shutdown_time, value|private, 0
method.set_key = event.system.shutdown, !!set_shutdown_time, {(branch, ((not,((system.shutdown_time)))), ((system.shutdown_time.set, (system.time))) )}
# Display shutdown time at shutdown
method.set_key = event.system.shutdown, ~log, ((print, "Shutdown time: ", ((system.shutdown_time)) ))
# Prevent command to fire up on 'event.download.paused/closed' event during shutdown
method.set_key = event.download.paused, ~print_name,  {(branch, ((not,((system.shutdown_time)))), ((print, ((d.name)))) )}
```