### PR TITLE
Fix 'list' type method

### DIFF
--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -139,6 +139,8 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
   case rpc::object_storage::flag_function_type:
     system_method_generate_command2(&value, itrArgs, args.end());
     break;
+  case rpc::object_storage::flag_list_type:
+    break;
   case rpc::object_storage::flag_multi_type:
     break;
   default:
@@ -152,7 +154,17 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
   if (!(flags & rpc::object_storage::flag_private))
     cmd_flags |= rpc::CommandMap::flag_public_xmlrpc;
 
-  control->object_storage()->insert_str(rawKey, value, flags);
+  if ((flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_list_type) {
+    torrent::Object valueList = torrent::Object::create_list();
+    torrent::Object::list_type& valueListType = valueList.as_list();
+
+    if ((itrArgs)->is_list())
+      valueListType = (itrArgs)->as_list();
+
+    control->object_storage()->insert_str(rawKey, valueList, flags);
+  } else {
+    control->object_storage()->insert_str(rawKey, value, flags);
+  }
 
   if ((flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_function_type ||
       (flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_multi_type) {
@@ -206,6 +218,13 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
         (create_new_key<5>(rawKey, ".set"),
          std::bind(&rpc::object_storage::set_str_string, control->object_storage(), rawKey, std::placeholders::_2),
          &rpc::command_base_call_string<rpc::target_type>,
+         cmd_flags, NULL, NULL);
+      break;
+    case rpc::object_storage::flag_list_type:
+      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_list<rpc::target_type> >::type>
+        (create_new_key<5>(rawKey, ".set"),
+         std::bind(&rpc::object_storage::set_str_list, control->object_storage(), rawKey, std::placeholders::_2),
+         &rpc::command_base_call_list<rpc::target_type>,
          cmd_flags, NULL, NULL);
       break;
     case rpc::object_storage::flag_function_type:
@@ -310,10 +329,6 @@ system_method_insert(const torrent::Object::list_type& args) {
       new_flags = rpc::object_storage::flag_string_type;
     else if (options.find("list") != std::string::npos)
       new_flags = rpc::object_storage::flag_list_type;
-    else if (options.find("simple") != std::string::npos)
-      new_flags = rpc::object_storage::flag_function_type;
-    else 
-      throw torrent::input_error("No support for 'list' variable type.");
 
     if (options.find("static") != std::string::npos)
       new_flags |= rpc::object_storage::flag_static;
@@ -447,6 +462,9 @@ initialize_command_dynamic() {
 
   CMD2_ANY_LIST    ("method.insert",             std::bind(&system_method_insert, std::placeholders::_2));
   CMD2_ANY_LIST    ("method.insert.value",       std::bind(&system_method_insert_object, std::placeholders::_2, rpc::object_storage::flag_value_type));
+  CMD2_ANY_LIST    ("method.insert.bool",        std::bind(&system_method_insert_object, std::placeholders::_2, rpc::object_storage::flag_bool_type));
+  CMD2_ANY_LIST    ("method.insert.string",      std::bind(&system_method_insert_object, std::placeholders::_2, rpc::object_storage::flag_string_type));
+  CMD2_ANY_LIST    ("method.insert.list",        std::bind(&system_method_insert_object, std::placeholders::_2, rpc::object_storage::flag_list_type));
 
   CMD2_METHOD_INSERT("method.insert.simple",     rpc::object_storage::flag_function_type);
   CMD2_METHOD_INSERT("method.insert.c_simple",   rpc::object_storage::flag_constant | rpc::object_storage::flag_function_type);


### PR DESCRIPTION
Fix 'list' type method: although there was an [attempt](https://github.com/rakshasa/rtorrent/commit/d0d52cdda1573c2bfd952184923cc87065f2dbb3#diff-eaaa13a5fc788064fdf9c24cd188fcdf) to deal with 'list' types but it never worked (at least since `v0.9.0`).
Now we can create/redefine arrays, even dynamically as well.

Similarly to `method.insert.value` method, add the following methods that creates public, mutable properties:
- `method.insert.bool`
- `method.insert.string`
- `method.insert.list`

Examples:
```ini
# Defining properties
method.insert = foo1, list, {"x1", "x2", "x3"}
method.insert = foo2, list|private, {10, 20, 30}
method.insert = bar1, list|const,
method.insert = bar2, list
method.insert.list = foo3, {"z1", "z2", "z3"}

# Accessing second element of an array
print=(array.at, (foo1), (value,1))
# Redefine array
foo1.set={1, 2}
# Calculation
print=(math.add, (foo1))
# Size of an array
print=(array.size, (foo1))
# Redefine array dynamically
foo1.set="$d.multicall2=active, cat=$d.state="
```