### PR TITLE
Fix cross compilation, based on OpenWRT patch

### DIFF
--- a/scripts/checks.m4
+++ b/scripts/checks.m4
@@ -96,7 +96,7 @@ AC_DEFUN([TORRENT_CHECK_KQUEUE], [
 AC_DEFUN([TORRENT_CHECK_KQUEUE_SOCKET_ONLY], [
   AC_MSG_CHECKING(whether kqueue supports pipes and ptys)
 
-  AC_RUN_IFELSE([AC_LANG_SOURCE([
+  AC_LINK_IFELSE([AC_LANG_SOURCE([
       #include <fcntl.h>
       #include <stdlib.h>
       #include <unistd.h>

--- a/scripts/common.m4
+++ b/scripts/common.m4
@@ -168,7 +168,7 @@ AC_DEFUN([TORRENT_CHECK_EXECINFO], [
 AC_DEFUN([TORRENT_CHECK_ALIGNED], [
   AC_MSG_CHECKING(the byte alignment)
 
-  AC_RUN_IFELSE([AC_LANG_SOURCE([
+  AC_LINK_IFELSE([AC_LANG_SOURCE([
       #include <inttypes.h>
       int main() {
         char buf@<:@8@:>@ = { 0, 0, 0, 0, 1, 0, 0, 0 };


### PR DESCRIPTION
[Vincent: tweak the patch for version 0.13.6]
[Bernd: tweak the patch for version 0.13.7]

Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>
Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libtorrent/0001-Fix-cross-compilation-based-on-OpenWRT-patch.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>