### PR TITLE
Added log.append_file command

### DIFF
--- a/src/command_logging.cc
+++ b/src/command_logging.cc
@@ -45,12 +45,12 @@ apply_log_open(int output_flags, const torrent::Object::list_type& args) {
     file_name += buffer;
   }
 
+  bool append = (output_flags & log_flag_append_file);
+
   if ((output_flags & log_flag_use_gz))
-    torrent::log_open_gz_file_output(output_id.c_str(), file_name.c_str());
-  else if ((output_flags & log_flag_append_file))
-    torrent::log_open_file_output_append(output_id.c_str(), file_name.c_str());
+    torrent::log_open_gz_file_output(output_id.c_str(), file_name.c_str(), append);
   else
-    torrent::log_open_file_output(output_id.c_str(), file_name.c_str());
+    torrent::log_open_file_output(output_id.c_str(), file_name.c_str(), append);
 
   while (itr != args.end())
     log_add_group_output_str((itr++)->as_string().c_str(), output_id.c_str());
@@ -134,6 +134,7 @@ initialize_command_logging() {
   CMD2_ANY_LIST    ("log.open_file_pid",    std::bind(&apply_log_open, log_flag_append_pid, std::placeholders::_2));
   CMD2_ANY_LIST    ("log.open_gz_file_pid", std::bind(&apply_log_open, log_flag_append_pid | log_flag_use_gz, std::placeholders::_2));
   CMD2_ANY_LIST    ("log.append_file",      std::bind(&apply_log_open, log_flag_append_file, std::placeholders::_2));
+  CMD2_ANY_LIST    ("log.append_gz_file",   std::bind(&apply_log_open, log_flag_append_file, std::placeholders::_2));
 
   CMD2_ANY_STRING_V("log.close",      std::bind(&torrent::log_close_output_str, std::placeholders::_2));
 

--- a/src/command_logging.cc
+++ b/src/command_logging.cc
@@ -20,6 +20,7 @@
 
 static const int log_flag_use_gz = 0x1;
 static const int log_flag_append_pid = 0x2;
+static const int log_flag_append_file = 0x4;
 
 void
 log_add_group_output_str(const char* group_name, const char* output_id) {
@@ -46,6 +47,8 @@ apply_log_open(int output_flags, const torrent::Object::list_type& args) {
 
   if ((output_flags & log_flag_use_gz))
     torrent::log_open_gz_file_output(output_id.c_str(), file_name.c_str());
+  else if ((output_flags & log_flag_append_file))
+    torrent::log_open_file_output_append(output_id.c_str(), file_name.c_str());
   else
     torrent::log_open_file_output(output_id.c_str(), file_name.c_str());
 
@@ -130,6 +133,7 @@ initialize_command_logging() {
   CMD2_ANY_LIST    ("log.open_gz_file",     std::bind(&apply_log_open, log_flag_use_gz, std::placeholders::_2));
   CMD2_ANY_LIST    ("log.open_file_pid",    std::bind(&apply_log_open, log_flag_append_pid, std::placeholders::_2));
   CMD2_ANY_LIST    ("log.open_gz_file_pid", std::bind(&apply_log_open, log_flag_append_pid | log_flag_use_gz, std::placeholders::_2));
+  CMD2_ANY_LIST    ("log.append_file",      std::bind(&apply_log_open, log_flag_append_file, std::placeholders::_2));
 
   CMD2_ANY_STRING_V("log.close",      std::bind(&torrent::log_close_output_str, std::placeholders::_2));
 


### PR DESCRIPTION
If https://github.com/rakshasa/libtorrent/pull/195 gets approved, this makes use of new log_open_file_output_append function.

Meant to have identical behavior to "log.open_file", but append file when opening instead of truncate/overwrite.