### PR TITLE
Fix possible crash with save_input_history

### DIFF
--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -392,7 +392,7 @@ Root::set_input_history_size(int size) {
 
 void
 Root::load_input_history() {
-  if (!m_control->core()->download_store()->is_enabled()) {
+  if (m_control == NULL || !m_control->core()->download_store()->is_enabled()) {
     lt_log_print(torrent::LOG_DEBUG, "ignoring input history file");
     return;
   }
@@ -460,7 +460,7 @@ Root::load_input_history() {
 
 void
 Root::save_input_history() {
-  if (!m_control->core()->download_store()->is_enabled())
+  if (m_control == NULL || !m_control->core()->download_store()->is_enabled())
     return;
 
   std::string history_filename = m_control->core()->download_store()->path() + "rtorrent.input_history";


### PR DESCRIPTION
Fix possible crash during startup with `save_input_history` method caused by putting "plain" `session.save=` command into rtorrent config file.

 
Closes: https://github.com/rakshasa/rtorrent/issues/928
Refers to: https://github.com/rakshasa/rtorrent/commit/a3a384b049497433bd51c8b6e4eb11bc94420046