### PR TITLE
few missing sub-commands of network and throttle for the RPC interface

### DIFF
--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -286,10 +286,10 @@ initialize_command_network() {
   CMD2_ANY         ("network.proxy_address",       std::bind(&core::Manager::proxy_address, control->core()));
   CMD2_ANY_STRING_V("network.proxy_address.set",   std::bind(&core::Manager::set_proxy_address, control->core(), std::placeholders::_2));
 
-  CMD2_ANY         ("network.open_files",       std::bind(&torrent::FileManager::open_files, fileManager));
+  CMD2_ANY         ("network.open_files",           std::bind(&torrent::FileManager::open_files, fileManager));
   CMD2_ANY         ("network.max_open_files",       std::bind(&torrent::FileManager::max_open_files, fileManager));
   CMD2_ANY_VALUE_V ("network.max_open_files.set",   std::bind(&torrent::FileManager::set_max_open_files, fileManager, std::placeholders::_2));
-  CMD2_ANY         ("network.total_handshakes",         std::bind(&torrent::total_handshakes));
+  CMD2_ANY         ("network.total_handshakes",     std::bind(&torrent::total_handshakes));
   CMD2_ANY         ("network.open_sockets",         std::bind(&torrent::ConnectionManager::size, cm));
   CMD2_ANY         ("network.max_open_sockets",     std::bind(&torrent::ConnectionManager::max_size, cm));
   CMD2_ANY_VALUE_V ("network.max_open_sockets.set", std::bind(&torrent::ConnectionManager::set_max_size, cm, std::placeholders::_2));

--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -286,8 +286,10 @@ initialize_command_network() {
   CMD2_ANY         ("network.proxy_address",       std::bind(&core::Manager::proxy_address, control->core()));
   CMD2_ANY_STRING_V("network.proxy_address.set",   std::bind(&core::Manager::set_proxy_address, control->core(), std::placeholders::_2));
 
+  CMD2_ANY         ("network.open_files",       std::bind(&torrent::FileManager::open_files, fileManager));
   CMD2_ANY         ("network.max_open_files",       std::bind(&torrent::FileManager::max_open_files, fileManager));
   CMD2_ANY_VALUE_V ("network.max_open_files.set",   std::bind(&torrent::FileManager::set_max_open_files, fileManager, std::placeholders::_2));
+  CMD2_ANY         ("network.total_handshakes",         std::bind(&torrent::total_handshakes));
   CMD2_ANY         ("network.open_sockets",         std::bind(&torrent::ConnectionManager::size, cm));
   CMD2_ANY         ("network.max_open_sockets",     std::bind(&torrent::ConnectionManager::max_size, cm));
   CMD2_ANY_VALUE_V ("network.max_open_sockets.set", std::bind(&torrent::ConnectionManager::set_max_size, cm, std::placeholders::_2));

--- a/src/command_throttle.cc
+++ b/src/command_throttle.cc
@@ -176,9 +176,9 @@ throttle_update(const char* variable, int64_t value) {
 
 void
 initialize_command_throttle() {
-  CMD2_ANY         ("throttle.unchoked_uploads",   std::bind(&torrent::ResourceManager::currently_upload_unchoked, torrent::resource_manager()));
+  CMD2_ANY         ("throttle.unchoked_uploads",       std::bind(&torrent::ResourceManager::currently_upload_unchoked, torrent::resource_manager()));
   CMD2_ANY         ("throttle.max_unchoked_uploads",   std::bind(&torrent::ResourceManager::max_upload_unchoked, torrent::resource_manager()));
-  CMD2_ANY         ("throttle.unchoked_downloads", std::bind(&torrent::ResourceManager::currently_download_unchoked, torrent::resource_manager()));
+  CMD2_ANY         ("throttle.unchoked_downloads",     std::bind(&torrent::ResourceManager::currently_download_unchoked, torrent::resource_manager()));
   CMD2_ANY         ("throttle.max_unchoked_downloads", std::bind(&torrent::ResourceManager::max_download_unchoked, torrent::resource_manager()));
 
   CMD2_VAR_VALUE   ("throttle.min_peers.normal", 100);

--- a/src/command_throttle.cc
+++ b/src/command_throttle.cc
@@ -177,7 +177,9 @@ throttle_update(const char* variable, int64_t value) {
 void
 initialize_command_throttle() {
   CMD2_ANY         ("throttle.unchoked_uploads",   std::bind(&torrent::ResourceManager::currently_upload_unchoked, torrent::resource_manager()));
+  CMD2_ANY         ("throttle.max_unchoked_uploads",   std::bind(&torrent::ResourceManager::max_upload_unchoked, torrent::resource_manager()));
   CMD2_ANY         ("throttle.unchoked_downloads", std::bind(&torrent::ResourceManager::currently_download_unchoked, torrent::resource_manager()));
+  CMD2_ANY         ("throttle.max_unchoked_downloads", std::bind(&torrent::ResourceManager::max_download_unchoked, torrent::resource_manager()));
 
   CMD2_VAR_VALUE   ("throttle.min_peers.normal", 100);
   CMD2_VAR_VALUE   ("throttle.max_peers.normal", 200);


### PR DESCRIPTION
Adding few missing commands to the RPC interface:
```
network.total_handshakes
network.open_files
throttle.max_unchoked_uploads
throttle.max_unchoked_downloads
```