### PR TITLE
Fix NULL pointer dereference

### DIFF
--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -460,7 +460,7 @@ Root::load_input_history() {
 
 void
 Root::save_input_history() {
-  if (!m_control->core()->download_store()->is_enabled())
+  if (m_control == NULL || !m_control->core()->download_store()->is_enabled())
     return;
 
   std::string history_filename = m_control->core()->download_store()->path() + "rtorrent.input_history";


### PR DESCRIPTION
In some cases `m_control` could be `NULL` in that case rtorrent will crash. Here's minimal sample config that causes crash:

    session.save = yes

Also, wanted to say that this also affects **0.9.8** too.