### PR TITLE
Introducing different handling to metadata files.

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -315,6 +315,9 @@ initialize_command_local() {
 
   CMD2_ANY_V       ("session.save",            std::bind(&core::DownloadList::session_save, dList));
 
+  CMD2_ANY         ("metadir.path",            std::bind(&core::DownloadStore::metadir_path, dStore));
+  CMD2_ANY_STRING_V("metadir.path.set",        std::bind(&core::DownloadStore::set_metadir_path, dStore, std::placeholders::_2));
+
 #define CMD2_EXECUTE(key, flags)                                         \
   CMD2_ANY(key, std::bind(&rpc::ExecFile::execute_object, &rpc::execFile, std::placeholders::_2, flags));
 

--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -285,9 +285,15 @@ DownloadFactory::receive_success() {
                             rpc::call_command_value("system.file.split_size"),
                             rpc::call_command_string("system.file.split_suffix"));
 
-  if (!rtorrent->has_key_string("directory"))
-    rpc::call_command("d.directory.set", m_variables["directory"], rpc::make_target(download));
-  else
+  if (!rtorrent->has_key_string("directory")) {
+    if (download->download()->info()->is_meta_download()) {
+      if(!rpc::call_command("metadir.path").is_string_empty())
+        rpc::call_command("d.directory.set", rpc::call_command("metadir.path"), rpc::make_target(download));
+      else
+        rpc::call_command("d.directory.set", rpc::call_command("session.path"), rpc::make_target(download));
+    } else
+      rpc::call_command("d.directory.set", m_variables["directory"], rpc::make_target(download));
+  } else
     rpc::call_command("d.directory_base.set", rtorrent->get_key("directory"), rpc::make_target(download));
 
   if (!m_session && m_variables["tied_to_file"].as_value())

--- a/src/core/download_store.cc
+++ b/src/core/download_store.cc
@@ -88,6 +88,14 @@ DownloadStore::disable() {
 }
 
 void
+DownloadStore::set_metadir_path(const std::string& path) {
+  if (!path.empty() && *path.rbegin() != '/')
+    m_metadir_path = rak::path_expand(path + '/');
+  else
+    m_metadir_path = rak::path_expand(path);
+}
+
+void
 DownloadStore::set_path(const std::string& path) {
   if (is_enabled())
     throw torrent::input_error("Tried to change session directory while it is enabled.");

--- a/src/core/download_store.h
+++ b/src/core/download_store.h
@@ -58,6 +58,8 @@ public:
   void                enable(bool lock);
   void                disable();
 
+  const std::string&  metadir_path() const                    { return m_metadir_path; }
+  void                set_metadir_path(const std::string& path);
   const std::string&  path() const                            { return m_path; }
   void                set_path(const std::string& path);
 
@@ -77,6 +79,7 @@ private:
   bool                write_bencode(const std::string& filename, const torrent::Object& obj, uint32_t skip_mask);
 
   std::string         m_path;
+  std::string         m_metadir_path;
   utils::Lockfile     m_lockfile;
 };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -107,6 +107,7 @@ parse_options(int argc, char** argv) {
     optionParser.insert_option('b', std::bind(&rpc::call_command_set_string, "network.bind_address.set", std::placeholders::_1));
     optionParser.insert_option('d', std::bind(&rpc::call_command_set_string, "directory.default.set", std::placeholders::_1));
     optionParser.insert_option('i', std::bind(&rpc::call_command_set_string, "ip", std::placeholders::_1));
+    optionParser.insert_option('m', std::bind(&rpc::call_command_set_string, "metadir.path.set", std::placeholders::_1));
     optionParser.insert_option('p', std::bind(&rpc::call_command_set_string, "network.port_range.set", std::placeholders::_1));
     optionParser.insert_option('s', std::bind(&rpc::call_command_set_string, "session", std::placeholders::_1));
 
@@ -413,6 +414,7 @@ main(int argc, char** argv) {
 
     CMD2_REDIRECT_GENERIC("directory", "directory.default.set");
     CMD2_REDIRECT_GENERIC("session",   "session.path.set");
+    CMD2_REDIRECT_GENERIC("metadir",   "metadir.path.set");
 
     CMD2_REDIRECT        ("check_hash", "pieces.hash.on_completion.set");
 
@@ -646,6 +648,7 @@ print_help() {
   std::cout << "  -b <a.b.c.d>      Bind the listening socket to this IP" << std::endl;
   std::cout << "  -i <a.b.c.d>      Change the IP that is sent to the tracker" << std::endl;
   std::cout << "  -p <int>-<int>    Set port range for incoming connections" << std::endl;
+  std::cout << "  -m <directory>    Save metadata files to this directory by default" << std::endl;
   std::cout << "  -d <directory>    Save torrents to this directory by default" << std::endl;
   std::cout << "  -s <directory>    Set the session directory" << std::endl;
   std::cout << "  -o key=opt,...    Set options, see 'rtorrent.rc' file" << std::endl;


### PR DESCRIPTION
Introducing a parameter to set the directory to store the metadata files
generated by rtorrent when a magnet link is passed.
Until now the metadata files are treated exactly like any other download
(in the users perspective), these changes aim to set the default to store the
metadata files inside the '.session' directory and, as the user wishes, the
location can be changed either using the 'metadir' command inside the ncurses
interface or in the configuration file, or by passing the '-m' flag as a
parameter to the command line.