### PR TITLE
Don't force the trackers to scrape when rTorrent first starts

### DIFF
--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -275,6 +275,9 @@ DownloadFactory::receive_success() {
 
   if (!rpc::call_command_value("trackers.use_udp"))
     download->enable_udp_trackers(false);
+  
+  // Don't force the trackers to scrape when rTorrent first starts
+  download->set_resume_flags(torrent::Download::start_skip_tracker);
 
   // Check first if we already have these values set in the session
   // torrent, so that it is safe to change the values.


### PR DESCRIPTION
rTorrent will do this gradually, so we can start connecting to peers right away.

This patch shaves approximately 5 minutes off the start time with thousands of torrents.