### PR TITLE
Fix common rtorrent xml-rpc crash when trying to queue an invalid task

### DIFF
--- a/src/rpc/command_scheduler_item.cc
+++ b/src/rpc/command_scheduler_item.cc
@@ -53,10 +53,14 @@ CommandSchedulerItem::enable(rak::timer t) {
 
   if (is_queued())
     disable();
+    
+  // Don't schedule invalid tasks for rpc commands
+  if (!m_task.is_valid())
+    return;
 
   // If 'first' is zero then we execute the task
   // immediately. ''interval()'' will not return zero so we never end
-  // up in an infinit loop.
+  // up in an infinite loop.
   m_timeScheduled = t;
   priority_queue_insert(&taskScheduler, &m_task, t);
 }


### PR DESCRIPTION
Instead of throwing an internal error and terminating the client, it's better not to queue the invalid task in the first place.
`C Caught internal_error: 'priority_queue_insert(...) called on an invalid item.'.`