### PR TITLE
utils: lockfile: avoid stack overflow for lockfile buffer

### DIFF
--- a/src/utils/lockfile.cc
+++ b/src/utils/lockfile.cc
@@ -98,7 +98,8 @@ Lockfile::try_lock() {
   int pos = ::gethostname(buf, 255);
 
   if (pos == 0) {
-    ::snprintf(buf + std::strlen(buf), 255, ":+%i\n", ::getpid());
+    ssize_t len = std::strlen(buf);
+    ::snprintf(buf + len, 255 - len, ":+%i\n", ::getpid());
     int __UNUSED result = ::write(fd, buf, std::strlen(buf));
   }
 


### PR DESCRIPTION
There appears to have been some change on openSUSE (likely some new
hardening flags for builds, or some glibc hardening) such that incorrect
buffer handling results in a segfault even if the buffer is never
overflowed.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>