### PR TITLE
Ensure compability check actually checks the type for files

### DIFF
--- a/src/rpc/command_impl.h
+++ b/src/rpc/command_impl.h
@@ -63,7 +63,7 @@ template <> struct target_type_id<core::Download*, core::Download*> { static con
 template <> inline bool
 is_target_compatible<target_type>(const target_type& target) { return true; }
 template <> inline bool
-is_target_compatible<torrent::File*>(const target_type& target) { return (target.first == target_type_id<torrent::File*>::value || target.first == command_base::target_file_itr); }
+is_target_compatible<torrent::File*>(const target_type& target) { return (target.first == command_base::target_file || target.first == command_base::target_file_itr); }
 
 template <> inline target_type
 get_target_cast<target_type>(target_type target, int type) { return target; }

--- a/src/rpc/command_impl.h
+++ b/src/rpc/command_impl.h
@@ -63,7 +63,7 @@ template <> struct target_type_id<core::Download*, core::Download*> { static con
 template <> inline bool
 is_target_compatible<target_type>(const target_type& target) { return true; }
 template <> inline bool
-is_target_compatible<torrent::File*>(const target_type& target) { return target.first == command_base::target_file || command_base::target_file_itr; }
+is_target_compatible<torrent::File*>(const target_type& target) { return (target.first == target_type_id<torrent::File*>::value || target.first == command_base::target_file_itr); }
 
 template <> inline target_type
 get_target_cast<target_type>(target_type target, int type) { return target; }


### PR DESCRIPTION
I'm actually not entirely sure if the other two checks are still necessary, but kept them in case there were some side effects I don't know about.

Fixes https://github.com/rakshasa/rtorrent/issues/854