### PR TITLE
Fix Link Time Optimizations

### DIFF
--- a/src/core/download_store.cc
+++ b/src/core/download_store.cc
@@ -183,7 +183,7 @@ DownloadStore::remove(Download* d) {
 // This also needs to check that it isn't a directory.
 bool
 not_correct_format(const utils::directory_entry& entry) {
-  return !DownloadStore::is_correct_format(entry.d_name);
+  return !DownloadStore::is_correct_format(entry.s_name);
 }
 
 utils::Directory

--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -403,7 +403,7 @@ Manager::try_create_download_from_meta_download(torrent::Object* bencode, const 
 
 utils::Directory
 path_expand_transform(std::string path, const utils::directory_entry& entry) {
-  return path + entry.d_name;
+  return path + entry.s_name;
 }
 
 // Move this somewhere better.
@@ -443,7 +443,7 @@ path_expand(std::vector<std::string>* paths, const std::string& pattern) {
       // Only include filenames starting with '.' if the pattern
       // starts with the same.
       itr->update((r.pattern()[0] != '.') ? utils::Directory::update_hide_dot : 0);
-      itr->erase(std::remove_if(itr->begin(), itr->end(), rak::on(rak::mem_ref(&utils::directory_entry::d_name), std::not1(r))), itr->end());
+      itr->erase(std::remove_if(itr->begin(), itr->end(), rak::on(rak::mem_ref(&utils::directory_entry::s_name), std::not1(r))), itr->end());
 
       std::transform(itr->begin(), itr->end(), std::back_inserter(nextCache), rak::bind1st(std::ptr_fun(&path_expand_transform), itr->path() + (itr->path() == "/" ? "" : "/")));
     }

--- a/src/input/path_input.cc
+++ b/src/input/path_input.cc
@@ -76,11 +76,11 @@ PathInput::pressed(int key) {
 struct _transform_filename {
   void operator () (utils::directory_entry& entry) {
 #ifdef __sun__
-    if (entry.d_type & S_IFDIR)
+    if (entry.s_type & S_IFDIR)
 #else
-    if (entry.d_type == DT_DIR)
+    if (entry.s_type == DT_DIR)
 #endif
-      entry.d_name += '/';
+      entry.s_name += '/';
   }
 };
 
@@ -105,7 +105,7 @@ PathInput::receive_do_complete() {
   if (r.first == r.second)
     return; // Show some nice colors here.
 
-  std::string base = rak::make_base<std::string>(r.first, r.second, rak::const_mem_ref(&utils::directory_entry::d_name));
+  std::string base = rak::make_base<std::string>(r.first, r.second, rak::const_mem_ref(&utils::directory_entry::s_name));
 
   // Clear the path after the cursor to make this code cleaner. It's
   // not really nessesary to add the complexity just because someone
@@ -142,12 +142,12 @@ PathInput::find_last_delim() {
 
 inline bool
 find_complete_compare(const utils::directory_entry& complete, const std::string& base) {
-  return complete.d_name.compare(0, base.size(), base);
+  return complete.s_name.compare(0, base.size(), base);
 }
 
 inline bool
 find_complete_not_compare(const utils::directory_entry& complete, const std::string& base) {
-  return !complete.d_name.compare(0, base.size(), base);
+  return !complete.s_name.compare(0, base.size(), base);
 }
 
 PathInput::range_type

--- a/src/main.cc
+++ b/src/main.cc
@@ -137,7 +137,7 @@ load_session_torrents() {
     f->set_session(true);
     f->set_init_load(true);
     f->slot_finished(std::bind(&rak::call_delete_func<core::DownloadFactory>, f));
-    f->load(entries.path() + first->d_name);
+    f->load(entries.path() + first->s_name);
     f->commit();
   }
 }

--- a/src/ui/element_string_list.h
+++ b/src/ui/element_string_list.h
@@ -86,7 +86,7 @@ public:
     m_list.clear();
 
     while (first != last)
-      m_list.push_back((first++)->d_name);
+      m_list.push_back((first++)->s_name);
 
     if (m_window != NULL) {
       lt_log_print(torrent::LOG_UI_EVENTS, "element_string_list: set dirent range (visible)");

--- a/src/utils/directory.cc
+++ b/src/utils/directory.cc
@@ -83,19 +83,19 @@ Directory::update(int flags) {
 
 #ifdef __sun__
     stat(entry->d_name, &s);
-    itr->d_fileno = entry->d_ino;
-    itr->d_reclen = 0;
-    itr->d_type = s.st_mode;
+    itr->s_fileno = entry->d_ino;
+    itr->s_reclen = 0;
+    itr->s_type = s.st_mode;
 #else
-    itr->d_fileno = entry->d_fileno;
-    itr->d_reclen = entry->d_reclen;
-    itr->d_type   = entry->d_type;
+    itr->s_fileno = entry->d_fileno;
+    itr->s_reclen = entry->d_reclen;
+    itr->s_type   = entry->d_type;
 #endif
 
 #ifdef DIRENT_NAMLEN_EXISTS_FOOBAR
-    itr->d_name   = std::string(entry->d_name, entry->d_name + entry->d_namlen);
+    itr->s_name   = std::string(entry->d_name, entry->d_name + entry->d_namlen);
 #else
-    itr->d_name   = std::string(entry->d_name);
+    itr->s_name   = std::string(entry->d_name);
 #endif
   }
 

--- a/src/utils/directory.h
+++ b/src/utils/directory.h
@@ -48,11 +48,11 @@ struct directory_entry {
   bool is_file() const { return true; }
 
   // The name and types should match POSIX.
-  uint32_t            d_fileno;
-  uint32_t            d_reclen; //Not used. Messes with Solaris.
-  uint8_t             d_type;
+  uint32_t            s_fileno;
+  uint32_t            s_reclen; //Not used. Messes with Solaris.
+  uint8_t             s_type;
 
-  std::string         d_name;
+  std::string         s_name;
 };
 
 class Directory : private std::vector<directory_entry> {
@@ -94,12 +94,12 @@ private:
   std::string         m_path;
 };
 
-inline bool operator == (const directory_entry& left, const directory_entry& right) { return left.d_name == right.d_name; }
-inline bool operator != (const directory_entry& left, const directory_entry& right) { return left.d_name != right.d_name; }
-inline bool operator <  (const directory_entry& left, const directory_entry& right) { return left.d_name <  right.d_name; }
-inline bool operator >  (const directory_entry& left, const directory_entry& right) { return left.d_name >  right.d_name; }
-inline bool operator <= (const directory_entry& left, const directory_entry& right) { return left.d_name <= right.d_name; }
-inline bool operator >= (const directory_entry& left, const directory_entry& right) { return left.d_name >= right.d_name; }
+inline bool operator == (const directory_entry& left, const directory_entry& right) { return left.s_name == right.s_name; }
+inline bool operator != (const directory_entry& left, const directory_entry& right) { return left.s_name != right.s_name; }
+inline bool operator <  (const directory_entry& left, const directory_entry& right) { return left.s_name <  right.s_name; }
+inline bool operator >  (const directory_entry& left, const directory_entry& right) { return left.s_name >  right.s_name; }
+inline bool operator <= (const directory_entry& left, const directory_entry& right) { return left.s_name <= right.s_name; }
+inline bool operator >= (const directory_entry& left, const directory_entry& right) { return left.s_name >= right.s_name; }
 
 }
 


### PR DESCRIPTION
This commit fixes compiling rTorrent with LTO (Link Time Optimizations). We just need to rename some variables in the `directory_entry` structure to avoid ODR and ZLIB conflicts. fixes #1264