### PR TITLE
Fix session file data corruption

### DIFF
--- a/src/core/download_store.cc
+++ b/src/core/download_store.cc
@@ -40,6 +40,7 @@
 
 #include <fstream>
 #include <stdio.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <rak/error_number.h>
 #include <rak/path.h>
@@ -121,6 +122,15 @@ DownloadStore::write_bencode(const std::string& filename, const torrent::Object&
     goto download_store_save_error;
 
   output.close();
+
+  // Ensure that the new file is actually written to the disk
+  int fd = ::open(filename.c_str(), O_WRONLY);
+  if (fd < 0)
+    goto download_store_save_error;
+
+  fdatasync(fd);
+  ::close(fd);
+
   return true;
 
 download_store_save_error:


### PR DESCRIPTION
From https://github.com/jesec/rtorrent/commit/f9a875b633eb083ec82f89ebeae8678ca424e8b2

This commit ensures session files land on the disk in the event of a system crash or power outage. It prevents data corruption of rTorrent session files, which causes torrent client breakage.

Optimizations from the initial implementation include:
1. Skipping unnecessary file metadata updates during the sync process. 
2. Skipping variable initialization since open will assign -1 on failure.