### PR TITLE
Fix critical memory leak

### DIFF
--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -171,7 +171,8 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
     throw torrent::input_error("Invalid type.");
   }
 
-  int cmd_flags = 0;
+  // We must initialize this varriable to prevent a critical memory leak
+  int cmd_flags = rpc::CommandMap::flag_delete_key;
 
   if (!(flags & rpc::object_storage::flag_static))
     cmd_flags |= rpc::CommandMap::flag_modifiable;


### PR DESCRIPTION
This commit fixes a critical memory leak with the inserting RPC commands. We must initialize the `cmd_flags` with the delete key, otherwise they hang around in memory forever; potentially leaking significant amounts of resources.