### PR TITLE
fix: use `fsync` for osx builds

### DIFF
--- a/src/core/download_store.cc
+++ b/src/core/download_store.cc
@@ -129,7 +129,11 @@ DownloadStore::write_bencode(const std::string& filename, const torrent::Object&
   if (fd < 0)
     goto download_store_save_error;
 
+#ifdef __APPLE__
+  fsync(fd);
+#else
   fdatasync(fd);
+#endif
   ::close(fd);
 
   return true;


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/192310