### PR TITLE
Simplify updating queue entries

### DIFF
--- a/rak/priority_queue.h
+++ b/rak/priority_queue.h
@@ -74,6 +74,10 @@ public:
     base_type::pop_back();
   }
 
+  void update() {
+    std::make_heap(begin(), end(), m_compare);
+  }
+
   void push(const value_type& value) {
     base_type::push_back(value);
     std::push_heap(begin(), end(), m_compare);
@@ -95,12 +99,8 @@ public:
     return true;
   }
 
-  // Removes 'itr' from the queue. This assumes 'itr' has been
-  // modified such that it has a higher priority than any other
-  // element in the queue.
+  // Removes 'itr' from the queue.
   void erase(iterator itr) {
-//     std::push_heap(begin(), ++itr, m_compare);
-//     pop();
     base_type::erase(itr);
     std::make_heap(begin(), end(), m_compare);
   }

--- a/src/core/curl_get.cc
+++ b/src/core/curl_get.cc
@@ -83,8 +83,7 @@ CurlGet::start() {
     // Normally libcurl should handle the timeout. But sometimes that doesn't
     // work right so we do a fallback timeout that just aborts the transfer.
     m_taskTimeout.slot() = std::bind(&CurlGet::receive_timeout, this);
-    priority_queue_erase(&taskScheduler, &m_taskTimeout);
-    priority_queue_insert(&taskScheduler, &m_taskTimeout, cachedTime + rak::timer::from_seconds(m_timeout + 5));
+    priority_queue_update(&taskScheduler, &m_taskTimeout, cachedTime + rak::timer::from_seconds(m_timeout + 5));
   }
 
   curl_easy_setopt(m_handle, CURLOPT_FORBID_REUSE,   (long)1);

--- a/src/core/curl_stack.cc
+++ b/src/core/curl_stack.cc
@@ -262,8 +262,7 @@ int
 CurlStack::set_timeout(void* handle, long timeout_ms, void* userp) {
   CurlStack* stack = (CurlStack*)userp;
 
-  priority_queue_erase(&taskScheduler, &stack->m_taskTimeout);
-  priority_queue_insert(&taskScheduler, &stack->m_taskTimeout, cachedTime + rak::timer::from_milliseconds(timeout_ms));
+  priority_queue_update(&taskScheduler, &stack->m_taskTimeout, cachedTime + rak::timer::from_milliseconds(timeout_ms));
 
   return 0;
 }

--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -145,8 +145,7 @@ struct view_downloads_filter : std::unary_function<Download*, bool> {
 
 void
 View::emit_changed() {
-  priority_queue_erase(&taskScheduler, &m_delayChanged);
-  priority_queue_insert(&taskScheduler, &m_delayChanged, cachedTime);
+  priority_queue_update(&taskScheduler, &m_delayChanged, cachedTime);
 }
 
 void

--- a/src/display/manager.cc
+++ b/src/display/manager.cc
@@ -64,8 +64,7 @@ Manager::force_redraw() {
 
 void
 Manager::schedule(Window* w, rak::timer t) {
-  rak::priority_queue_erase(&m_scheduler, w->task_update());
-  rak::priority_queue_insert(&m_scheduler, w->task_update(), t);
+  rak::priority_queue_update(&m_scheduler, w->task_update(), t);
   schedule_update(50000);
 }
 
@@ -114,8 +113,7 @@ Manager::schedule_update(uint32_t minInterval) {
   }
 
   if (!m_taskUpdate.is_queued() || m_taskUpdate.time() > m_scheduler.top()->time()) {
-    rak::priority_queue_erase(&taskScheduler, &m_taskUpdate);
-    rak::priority_queue_insert(&taskScheduler, &m_taskUpdate, std::max(m_scheduler.top()->time(), m_timeLastUpdate + minInterval));
+    rak::priority_queue_update(&taskScheduler, &m_taskUpdate, std::max(m_scheduler.top()->time(), m_timeLastUpdate + minInterval));
   }
 }
 


### PR DESCRIPTION
The erase/insert pattern can be replaced by a single method that updates an existing entry's timer, or inserting if it doesn't exist.

This has much less impact than the libtorrent change it's based on, but might as well be consistent.