### PR TITLE
Resolve scgi software crash

### DIFF
--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -200,7 +200,7 @@ SCgiTask::event_read() {
 
 void
 SCgiTask::event_write() {
-  int bytes = ::send(m_fileDesc, m_position, m_bufferSize, 0);
+  int bytes = ::send(m_fileDesc, m_position, m_bufferSize, MSG_NOSIGNAL);
 
   if (bytes == -1) {
     if (!rak::error_number::current().is_blocked_momentary())


### PR DESCRIPTION
This commit resolves a scgi software crash when the scgi socket is closed before the message can be sent. It instructs `::send()` not to send a `SIGPIPE` termination signal. Instead the value `-1` is returned and handled bellow. The `SCgiTask` is closed.

```
Thread 3 "rtorrent scgi" received signal SIGPIPE, Broken pipe.
                                                             [Switching to Thread 0x7fffe635c6c0 (LWP 2443872)]
0x00007ffff7929a84 in send () from /lib/x86_64-linux-gnu/libc.so.6
```