### PR TITLE
Convert CommandMap to use std::string instead of char*

### DIFF
--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -172,7 +172,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
   }
 
   // We must initialize this varriable to prevent a critical memory leak
-  int cmd_flags = rpc::CommandMap::flag_delete_key;
+  int cmd_flags = 0;
 
   if (!(flags & rpc::object_storage::flag_static))
     cmd_flags |= rpc::CommandMap::flag_modifiable;
@@ -287,7 +287,7 @@ system_method_insert(const torrent::Object::list_type& args) {
   if (rawKey.empty() || rpc::commands.has(rawKey))
     throw torrent::input_error("Invalid key.");
 
-  int flags = rpc::CommandMap::flag_delete_key | rpc::CommandMap::flag_modifiable | rpc::CommandMap::flag_public_xmlrpc;
+  int flags = rpc::CommandMap::flag_modifiable | rpc::CommandMap::flag_public_xmlrpc;
   int new_flags = rpc::parse_option_flags(itrArgs->as_string(), std::bind(&object_storage_parse_flag, std::placeholders::_1));
 
   if ((new_flags & rpc::object_storage::flag_private))
@@ -346,7 +346,7 @@ system_method_redirect(const torrent::Object::list_type& args) {
   std::string dest_key = torrent::object_create_string(args.back());
 
   rpc::commands.create_redirect(new_key, dest_key,
-                                rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_delete_key | rpc::CommandMap::flag_modifiable);
+                                rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_modifiable);
 
   return torrent::Object();
 }

--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -143,11 +143,11 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
     throw torrent::input_error("Invalid argument count.");
 
   torrent::Object::list_const_iterator itrArgs = args.begin();
-  const std::string& rawKey = (itrArgs++)->as_string();
+  const std::string& raw_key = (itrArgs++)->as_string();
 
-  if (rawKey.empty() ||
-      control->object_storage()->find_raw_string(torrent::raw_string::from_string(rawKey)) != control->object_storage()->end() ||
-      rpc::commands.has(rawKey) || rpc::commands.has(rawKey + ".set"))
+  if (raw_key.empty() ||
+      control->object_storage()->find_raw_string(torrent::raw_string::from_string(raw_key)) != control->object_storage()->end() ||
+      rpc::commands.has(raw_key) || rpc::commands.has(raw_key + ".set"))
     throw torrent::input_error("Invalid key.");
 
   torrent::Object value;
@@ -186,25 +186,25 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
     if ((itrArgs)->is_list())
       valueListType = (itrArgs)->as_list();
 
-    control->object_storage()->insert_str(rawKey, valueList, flags);
+    control->object_storage()->insert_str(raw_key, valueList, flags);
   } else {
-    control->object_storage()->insert_str(rawKey, value, flags);
+    control->object_storage()->insert_str(raw_key, value, flags);
   }
 
   if ((flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_function_type ||
       (flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_multi_type) {
 
     rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type> >::type>
-      (create_new_key(rawKey),
+      (raw_key,
        std::bind(&rpc::object_storage::call_function_str, control->object_storage(),
-                 rawKey, std::placeholders::_1, std::placeholders::_2),
+                 raw_key, std::placeholders::_1, std::placeholders::_2),
        &rpc::command_base_call<rpc::target_type>,
        cmd_flags, NULL, NULL);
 
   } else {
     rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type> >::type>
-      (create_new_key(rawKey),
-       std::bind(&rpc::object_storage::get_str, control->object_storage(), rawKey),
+      (raw_key,
+       std::bind(&rpc::object_storage::get_str, control->object_storage(), raw_key),
        &rpc::command_base_call<rpc::target_type>,
        cmd_flags, NULL, NULL);
   }
@@ -226,29 +226,29 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
     switch (flags & rpc::object_storage::mask_type) {
     case rpc::object_storage::flag_bool_type:
       rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_value<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_bool, control->object_storage(), rawKey, std::placeholders::_2),
+        (raw_key + ".set",
+         std::bind(&rpc::object_storage::set_str_bool, control->object_storage(), raw_key, std::placeholders::_2),
          &rpc::command_base_call_value<rpc::target_type>,
          cmd_flags, NULL, NULL);
       break;
     case rpc::object_storage::flag_value_type:
       rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_value<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_value, control->object_storage(), rawKey, std::placeholders::_2),
+        (raw_key + ".set",
+         std::bind(&rpc::object_storage::set_str_value, control->object_storage(), raw_key, std::placeholders::_2),
          &rpc::command_base_call_value<rpc::target_type>,
          cmd_flags, NULL, NULL);
       break;
     case rpc::object_storage::flag_string_type:
       rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_string<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_string, control->object_storage(), rawKey, std::placeholders::_2),
+        (raw_key + ".set",
+         std::bind(&rpc::object_storage::set_str_string, control->object_storage(), raw_key, std::placeholders::_2),
          &rpc::command_base_call_string<rpc::target_type>,
          cmd_flags, NULL, NULL);
       break;
     case rpc::object_storage::flag_list_type:
       rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_list<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_list, control->object_storage(), rawKey, std::placeholders::_2),
+        (raw_key + ".set",
+         std::bind(&rpc::object_storage::set_str_list, control->object_storage(), raw_key, std::placeholders::_2),
          &rpc::command_base_call_list<rpc::target_type>,
          cmd_flags, NULL, NULL);
       break;
@@ -345,7 +345,7 @@ system_method_redirect(const torrent::Object::list_type& args) {
   std::string new_key  = torrent::object_create_string(args.front());
   std::string dest_key = torrent::object_create_string(args.back());
 
-  rpc::commands.create_redirect(create_new_key(new_key), create_new_key(dest_key),
+  rpc::commands.create_redirect(new_key, dest_key,
                                 rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_delete_key | rpc::CommandMap::flag_modifiable);
 
   return torrent::Object();

--- a/src/command_helpers.h
+++ b/src/command_helpers.h
@@ -149,11 +149,11 @@ void initialize_commands();
 
 #define CMD2_REDIRECT_GENERIC_STR(from_key, to_key)                     \
   rpc::commands.create_redirect(from_key, to_key, \
-                                rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_no_target | rpc::CommandMap::flag_delete_key);
+                                rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_no_target);
 
 #define CMD2_REDIRECT_GENERIC_STR_NO_EXPORT(from_key, to_key)                     \
   rpc::commands.create_redirect(from_key, to_key, \
-                                rpc::CommandMap::flag_no_target | rpc::CommandMap::flag_delete_key);
+                                rpc::CommandMap::flag_no_target);
 
 //
 // Conversion of return types:

--- a/src/command_helpers.h
+++ b/src/command_helpers.h
@@ -148,11 +148,11 @@ void initialize_commands();
   rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_tracker_target | rpc::CommandMap::flag_dont_delete);
 
 #define CMD2_REDIRECT_GENERIC_STR(from_key, to_key)                     \
-  rpc::commands.create_redirect(create_new_key(from_key), create_new_key(to_key), \
+  rpc::commands.create_redirect(from_key, to_key, \
                                 rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_no_target | rpc::CommandMap::flag_delete_key);
 
 #define CMD2_REDIRECT_GENERIC_STR_NO_EXPORT(from_key, to_key)                     \
-  rpc::commands.create_redirect(create_new_key(from_key), create_new_key(to_key), \
+  rpc::commands.create_redirect(from_key, to_key, \
                                 rpc::CommandMap::flag_no_target | rpc::CommandMap::flag_delete_key);
 
 //
@@ -187,25 +187,5 @@ struct object_convert_type<Functor, void> {
 template <typename T>
 object_convert_type<T, void>
 object_convert_void(T f) { return f; }
-
-//
-// Key creation:
-//
-
-template <int postfix_size>
-inline const char*
-create_new_key(const std::string& key, const char postfix[postfix_size]) {
-  char *buffer = new char[key.size() + std::max(postfix_size, 1)];
-  std::memcpy(buffer, key.c_str(), key.size() + 1);
-  std::memcpy(buffer + key.size(), postfix, postfix_size);
-  return buffer;
-}
-
-inline const char*
-create_new_key(const std::string& key) {
-  char *buffer = new char[key.size() + 1];
-  std::memcpy(buffer, key.c_str(), key.size() + 1);
-  return buffer;
-}
 
 #endif

--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -135,7 +135,7 @@ initialize_xmlrpc() {
     if (!(itr->second.m_flags & rpc::CommandMap::flag_public_xmlrpc))
       continue;
 
-    rpc::xmlrpc.insert_command(itr->first, itr->second.m_parm, itr->second.m_doc);
+    rpc::xmlrpc.insert_command(itr->first.c_str(), itr->second.m_parm, itr->second.m_doc);
   }
 
   lt_log_print(torrent::LOG_RPC_EVENTS, "XMLRPC initialized with %u functions.", count);

--- a/src/rpc/command_map.cc
+++ b/src/rpc/command_map.cc
@@ -102,7 +102,7 @@ CommandMap::create_redirect(const key_type& key_new, const key_type& key_dest, i
 
   dest_itr->second.m_flags |= flag_has_redirects;
 
-  flags |= dest_itr->second.m_flags & ~(flag_delete_key | flag_has_redirects | flag_public_xmlrpc);
+  flags |= dest_itr->second.m_flags & ~(flag_has_redirects | flag_public_xmlrpc);
 
   // TODO: This is not honoring the public_xmlrpc flags!!!
   if (rpc::xmlrpc.is_valid() && (flags & flag_public_xmlrpc))

--- a/src/rpc/command_map.h
+++ b/src/rpc/command_map.h
@@ -46,10 +46,6 @@
 
 namespace rpc {
 
-struct command_map_comp : public std::binary_function<const char*, const char*, bool> {
-  bool operator () (const char* arg1, const char* arg2) const { return std::strcmp(arg1, arg2) < 0; }
-};
-
 struct command_map_data_type {
   // Some commands will need to share data, like get/set a variable. So
   // instead of using a single virtual member function, each command
@@ -73,9 +69,9 @@ struct command_map_data_type {
   const char*   m_doc;
 };
 
-class CommandMap : public std::map<const char*, command_map_data_type, command_map_comp> {
+class CommandMap : public std::map<std::string, command_map_data_type> {
 public:
-  typedef std::map<const char*, command_map_data_type, command_map_comp> base_type;
+  typedef std::map<std::string, command_map_data_type> base_type;
 
   typedef torrent::Object         mapped_type;
   typedef mapped_type::value_type mapped_value_type;
@@ -101,39 +97,37 @@ public:
   static const int flag_tracker_target = 0x400;
 
   CommandMap() {}
-  ~CommandMap();
+  ~CommandMap() {}
 
-  bool                has(const char* key) const        { return base_type::find(key) != base_type::end(); }
-  bool                has(const std::string& key) const { return has(key.c_str()); }
+  bool                has(const std::string& key) const { return base_type::find(key) != base_type::end(); }
 
   bool                is_modifiable(const_iterator itr) { return itr != end() && (itr->second.m_flags & flag_modifiable); }
 
-  iterator            insert(key_type key, int flags, const char* parm, const char* doc);
+  iterator            insert(const key_type& key, int flags, const char* parm, const char* doc);
 
   template <typename T, typename Slot>
   void
-  insert_slot(key_type key, Slot variable, command_base::any_slot targetSlot, int flags, const char* parm, const char* doc) {
+  insert_slot(const key_type& key, Slot variable, command_base::any_slot target_slot, int flags, const char* parm, const char* doc) {
     iterator itr = insert(key, flags, parm, doc);
     itr->second.m_variable.set_function<T>(variable);
-    itr->second.m_anySlot = targetSlot;
+    itr->second.m_anySlot = target_slot;
   }
 
-  //  void                insert(key_type key, const command_map_data_type src);
   void                erase(iterator itr);
 
-  void                create_redirect(key_type key_new, key_type key_dest, int flags);
+  void                create_redirect(const key_type& key_new, const key_type& key_dest, int flags);
 
-  const mapped_type   call(key_type key, const mapped_type& args = mapped_type());
-  const mapped_type   call(key_type key, target_type target, const mapped_type& args = mapped_type()) { return call_command(key, args, target); }
-  const mapped_type   call_catch(key_type key, target_type target, const mapped_type& args = mapped_type(), const char* err = "Command failed: ");
+  const mapped_type   call(const key_type& key, const mapped_type& args = mapped_type());
+  const mapped_type   call(const key_type& key, const target_type& target, const mapped_type& args = mapped_type()) { return call_command(key, args, target); }
+  const mapped_type   call_catch(const key_type& key, const target_type& target, const mapped_type& args = mapped_type(), const char* err = "Command failed: ");
 
-  const mapped_type   call_command  (key_type key, const mapped_type& arg, target_type target = target_type((int)command_base::target_generic, NULL));
-  const mapped_type   call_command  (iterator itr, const mapped_type& arg, target_type target = target_type((int)command_base::target_generic, NULL));
+  const mapped_type   call_command  (const key_type& key, const mapped_type& arg, const target_type& target = target_type((int)command_base::target_generic, NULL));
+  const mapped_type   call_command  (iterator itr, const mapped_type& arg, const target_type& target = target_type((int)command_base::target_generic, NULL));
 
-  const mapped_type   call_command_d(key_type key, core::Download* download, const mapped_type& arg)  { return call_command(key, arg, target_type((int)command_base::target_download, download)); }
-  const mapped_type   call_command_p(key_type key, torrent::Peer* peer, const mapped_type& arg)       { return call_command(key, arg, target_type((int)command_base::target_peer, peer)); }
-  const mapped_type   call_command_t(key_type key, torrent::Tracker* tracker, const mapped_type& arg) { return call_command(key, arg, target_type((int)command_base::target_tracker, tracker)); }
-  const mapped_type   call_command_f(key_type key, torrent::File* file, const mapped_type& arg)       { return call_command(key, arg, target_type((int)command_base::target_file, file)); }
+  const mapped_type   call_command_d(const key_type& key, core::Download* download, const mapped_type& arg)  { return call_command(key, arg, target_type((int)command_base::target_download, download)); }
+  const mapped_type   call_command_p(const key_type& key, torrent::Peer* peer, const mapped_type& arg)       { return call_command(key, arg, target_type((int)command_base::target_peer, peer)); }
+  const mapped_type   call_command_t(const key_type& key, torrent::Tracker* tracker, const mapped_type& arg) { return call_command(key, arg, target_type((int)command_base::target_tracker, tracker)); }
+  const mapped_type   call_command_f(const key_type& key, torrent::File* file, const mapped_type& arg)       { return call_command(key, arg, target_type((int)command_base::target_file, file)); }
 
 private:
   CommandMap(const CommandMap&);
@@ -175,7 +169,7 @@ create_object_list(const torrent::Object& o1, const torrent::Object& o2, const t
 }
 
 inline const CommandMap::mapped_type
-CommandMap::call(key_type key, const mapped_type& args) {
+CommandMap::call(const key_type& key, const mapped_type& args) {
   return call_command(key, args, make_target());
 }
 

--- a/src/rpc/command_map.h
+++ b/src/rpc/command_map.h
@@ -97,7 +97,6 @@ public:
   static const int flag_tracker_target = 0x400;
 
   CommandMap() {}
-  ~CommandMap() {}
 
   bool                has(const std::string& key) const { return base_type::find(key) != base_type::end(); }
 

--- a/src/rpc/command_map.h
+++ b/src/rpc/command_map.h
@@ -86,7 +86,6 @@ public:
   using base_type::find;
 
   static const int flag_dont_delete   = 0x1;
-  static const int flag_delete_key    = 0x2;
   static const int flag_public_xmlrpc = 0x4;
   static const int flag_modifiable    = 0x10;
   static const int flag_is_redirect   = 0x20;


### PR DESCRIPTION
This allows it to own its keys and clean them up automatically on destruction.

This fixes a very minor memory leak and removes a bunch of char* handling. I also changed any of the variable names to `lower_case` while I was in there.