### PR TITLE
Add clang-format/clang-tidy config files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ BinPackArguments: false
 BinPackParameters: false
 BreakConstructorInitializers: AfterColon
 BreakStringLiterals: false
-ColumnLimit: 130
+ColumnLimit: 0
 ContinuationIndentWidth: 2
 IndentCaseLabels: false
 IndentWidth: 2

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+---
+BasedOnStyle: LLVM
+Standard: c++14
+
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+BinPackArguments: false
+BinPackParameters: false
+BreakConstructorInitializers: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 130
+ContinuationIndentWidth: 2
+IndentCaseLabels: false
+IndentWidth: 2
+PenaltyReturnTypeOnItsOwnLine: 130
+PointerAlignment: Left
+
+AlignEscapedNewlines: Right
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: false
+AlignConsecutiveMacros:
+  Enabled: true
+AlignConsecutiveAssignments:
+  Enabled: true  
+
+IncludeCategories:
+  - Regex: "^(config|globals)\\.h"
+    Priority: -1
+  - Regex: "^torrent/.*"
+    Priority: 1

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+---
+Checks: '-*,bugprone-*,readability-identifier-naming,performance-for-range-copy'
+FormatStyle: 'file'
+CheckOptions:
+  - key: readability-identifier-naming.LocalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.FunctionCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.ClassConstantCase
+    value: lower_case

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,bugprone-*,readability-identifier-naming,performance-for-range-copy'
+Checks: '-*,readability-identifier-naming'
 FormatStyle: 'file'
 CheckOptions:
   - key: readability-identifier-naming.LocalVariableCase

--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -40,25 +40,23 @@
 #include <torrent/utils/log.h>
 #include <torrent/utils/option_strings.h>
 
-#include "globals.h"
-#include "control.h"
 #include "command_helpers.h"
+#include "control.h"
+#include "globals.h"
 #include "rpc/parse.h"
 #include "rpc/parse_options.h"
 
-static std::vector<std::pair<const char*, int>> object_storage_flags = {
-  { "multi", rpc::object_storage::flag_multi_type },
-  { "simple", rpc::object_storage::flag_function_type },
-  { "value", rpc::object_storage::flag_value_type },
-  { "bool", rpc::object_storage::flag_bool_type },
-  { "string", rpc::object_storage::flag_string_type },
-  { "list", rpc::object_storage::flag_list_type },
+static std::vector<std::pair<const char*, int>> object_storage_flags = {{"multi", rpc::object_storage::flag_multi_type},
+                                                                        {"simple", rpc::object_storage::flag_function_type},
+                                                                        {"value", rpc::object_storage::flag_value_type},
+                                                                        {"bool", rpc::object_storage::flag_bool_type},
+                                                                        {"string", rpc::object_storage::flag_string_type},
+                                                                        {"list", rpc::object_storage::flag_list_type},
 
-  { "static", rpc::object_storage::flag_static },
-  { "private", rpc::object_storage::flag_private },
-  { "const", rpc::object_storage::flag_constant },
-  { "rlookup", rpc::object_storage::flag_rlookup }
-};
+                                                                        {"static", rpc::object_storage::flag_static},
+                                                                        {"private", rpc::object_storage::flag_private},
+                                                                        {"const", rpc::object_storage::flag_constant},
+                                                                        {"rlookup", rpc::object_storage::flag_rlookup}};
 
 static int
 object_storage_parse_flag(const std::string& flag) {
@@ -84,7 +82,9 @@ system_method_generate_command(torrent::Object::list_const_iterator first, torre
 }
 
 void
-system_method_generate_command2(torrent::Object* object, torrent::Object::list_const_iterator first, torrent::Object::list_const_iterator last) {
+system_method_generate_command2(torrent::Object*                     object,
+                                torrent::Object::list_const_iterator first,
+                                torrent::Object::list_const_iterator last) {
   if (first == last) {
     // TODO: Use empty object.
     *object = "";
@@ -109,7 +109,7 @@ system_method_generate_command2(torrent::Object* object, torrent::Object::list_c
   if (first + 1 == last) {
     if (!first->is_dict_key())
       throw torrent::input_error("New command of wrong type.");
-    
+
     *object = *first;
 
     uint32_t flags = object->flags() & torrent::Object::mask_function;
@@ -122,9 +122,9 @@ system_method_generate_command2(torrent::Object* object, torrent::Object::list_c
     while (first != last) {
       if (!first->is_dict_key())
         throw torrent::input_error("New command of wrong type.");
-      
+
       object->as_list().push_back(*first++);
-      
+
       uint32_t flags = object->as_list().back().flags() & torrent::Object::mask_function;
       object->as_list().back().unset_flags(torrent::Object::mask_function);
       object->as_list().back().set_flags((flags >> 1) & torrent::Object::mask_function);
@@ -134,7 +134,7 @@ system_method_generate_command2(torrent::Object* object, torrent::Object::list_c
 
 // torrent::Object
 // system_method_insert_function(const torrent::Object::list_type& args, int flags) {
-  
+
 // }
 
 torrent::Object
@@ -143,7 +143,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
     throw torrent::input_error("Invalid argument count.");
 
   torrent::Object::list_const_iterator itrArgs = args.begin();
-  const std::string& rawKey = (itrArgs++)->as_string();
+  const std::string&                   rawKey  = (itrArgs++)->as_string();
 
   if (rawKey.empty() ||
       control->object_storage()->find_raw_string(torrent::raw_string::from_string(rawKey)) != control->object_storage()->end() ||
@@ -180,7 +180,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
     cmd_flags |= rpc::CommandMap::flag_public_xmlrpc;
 
   if ((flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_list_type) {
-    torrent::Object valueList = torrent::Object::create_list();
+    torrent::Object             valueList     = torrent::Object::create_list();
     torrent::Object::list_type& valueListType = valueList.as_list();
 
     if ((itrArgs)->is_list())
@@ -194,19 +194,23 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
   if ((flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_function_type ||
       (flags & rpc::object_storage::mask_type) == rpc::object_storage::flag_multi_type) {
 
-    rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type> >::type>
-      (create_new_key(rawKey),
-       std::bind(&rpc::object_storage::call_function_str, control->object_storage(),
-                 rawKey, std::placeholders::_1, std::placeholders::_2),
-       &rpc::command_base_call<rpc::target_type>,
-       cmd_flags, NULL, NULL);
+    rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type>>::type>(
+      create_new_key(rawKey),
+      std::bind(
+        &rpc::object_storage::call_function_str, control->object_storage(), rawKey, std::placeholders::_1, std::placeholders::_2),
+      &rpc::command_base_call<rpc::target_type>,
+      cmd_flags,
+      NULL,
+      NULL);
 
   } else {
-    rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type> >::type>
-      (create_new_key(rawKey),
-       std::bind(&rpc::object_storage::get_str, control->object_storage(), rawKey),
-       &rpc::command_base_call<rpc::target_type>,
-       cmd_flags, NULL, NULL);
+    rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type>>::type>(
+      create_new_key(rawKey),
+      std::bind(&rpc::object_storage::get_str, control->object_storage(), rawKey),
+      &rpc::command_base_call<rpc::target_type>,
+      cmd_flags,
+      NULL,
+      NULL);
   }
 
   // Not the right argument.
@@ -220,41 +224,50 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
 
   // TODO: Next... Make test class for this.
 
-//   // Ehm... no proper handling if these throw.
+  //   // Ehm... no proper handling if these throw.
 
   if (!(flags & rpc::object_storage::flag_constant)) {
     switch (flags & rpc::object_storage::mask_type) {
     case rpc::object_storage::flag_bool_type:
-      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_value<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_bool, control->object_storage(), rawKey, std::placeholders::_2),
-         &rpc::command_base_call_value<rpc::target_type>,
-         cmd_flags, NULL, NULL);
+      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_value<rpc::target_type>>::type>(
+        create_new_key<5>(rawKey, ".set"),
+        std::bind(&rpc::object_storage::set_str_bool, control->object_storage(), rawKey, std::placeholders::_2),
+        &rpc::command_base_call_value<rpc::target_type>,
+        cmd_flags,
+        NULL,
+        NULL);
       break;
     case rpc::object_storage::flag_value_type:
-      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_value<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_value, control->object_storage(), rawKey, std::placeholders::_2),
-         &rpc::command_base_call_value<rpc::target_type>,
-         cmd_flags, NULL, NULL);
+      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_value<rpc::target_type>>::type>(
+        create_new_key<5>(rawKey, ".set"),
+        std::bind(&rpc::object_storage::set_str_value, control->object_storage(), rawKey, std::placeholders::_2),
+        &rpc::command_base_call_value<rpc::target_type>,
+        cmd_flags,
+        NULL,
+        NULL);
       break;
     case rpc::object_storage::flag_string_type:
-      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_string<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_string, control->object_storage(), rawKey, std::placeholders::_2),
-         &rpc::command_base_call_string<rpc::target_type>,
-         cmd_flags, NULL, NULL);
+      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_string<rpc::target_type>>::type>(
+        create_new_key<5>(rawKey, ".set"),
+        std::bind(&rpc::object_storage::set_str_string, control->object_storage(), rawKey, std::placeholders::_2),
+        &rpc::command_base_call_string<rpc::target_type>,
+        cmd_flags,
+        NULL,
+        NULL);
       break;
     case rpc::object_storage::flag_list_type:
-      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_list<rpc::target_type> >::type>
-        (create_new_key<5>(rawKey, ".set"),
-         std::bind(&rpc::object_storage::set_str_list, control->object_storage(), rawKey, std::placeholders::_2),
-         &rpc::command_base_call_list<rpc::target_type>,
-         cmd_flags, NULL, NULL);
+      rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call_list<rpc::target_type>>::type>(
+        create_new_key<5>(rawKey, ".set"),
+        std::bind(&rpc::object_storage::set_str_list, control->object_storage(), rawKey, std::placeholders::_2),
+        &rpc::command_base_call_list<rpc::target_type>,
+        cmd_flags,
+        NULL,
+        NULL);
       break;
     case rpc::object_storage::flag_function_type:
     case rpc::object_storage::flag_multi_type:
-    default: break;
+    default:
+      break;
     }
   }
 
@@ -282,12 +295,12 @@ system_method_insert(const torrent::Object::list_type& args) {
     throw torrent::input_error("Invalid argument count.");
 
   torrent::Object::list_const_iterator itrArgs = args.begin();
-  const std::string& rawKey = (itrArgs++)->as_string();
+  const std::string&                   rawKey  = (itrArgs++)->as_string();
 
   if (rawKey.empty() || rpc::commands.has(rawKey))
     throw torrent::input_error("Invalid key.");
 
-  int flags = rpc::CommandMap::flag_delete_key | rpc::CommandMap::flag_modifiable | rpc::CommandMap::flag_public_xmlrpc;
+  int flags     = rpc::CommandMap::flag_delete_key | rpc::CommandMap::flag_modifiable | rpc::CommandMap::flag_public_xmlrpc;
   int new_flags = rpc::parse_option_flags(itrArgs->as_string(), std::bind(&object_storage_parse_flag, std::placeholders::_1));
 
   if ((new_flags & rpc::object_storage::flag_private))
@@ -299,14 +312,11 @@ system_method_insert(const torrent::Object::list_type& args) {
   torrent::Object::list_type new_args;
   new_args.push_back(rawKey);
 
-  if ((new_flags & rpc::object_storage::flag_function_type) ||
-      (new_flags & rpc::object_storage::flag_multi_type)) {
+  if ((new_flags & rpc::object_storage::flag_function_type) || (new_flags & rpc::object_storage::flag_multi_type)) {
     new_args.push_back(system_method_generate_command(++itrArgs, args.end()));
 
-  } else if ((new_flags & rpc::object_storage::flag_value_type) ||
-             (new_flags & rpc::object_storage::flag_bool_type) ||
-             (new_flags & rpc::object_storage::flag_string_type) ||
-             (new_flags & rpc::object_storage::flag_list_type)) {
+  } else if ((new_flags & rpc::object_storage::flag_value_type) || (new_flags & rpc::object_storage::flag_bool_type) ||
+             (new_flags & rpc::object_storage::flag_string_type) || (new_flags & rpc::object_storage::flag_list_type)) {
     if (++itrArgs != args.end())
       new_args.insert(new_args.end(), itrArgs, args.end());
 
@@ -345,8 +355,10 @@ system_method_redirect(const torrent::Object::list_type& args) {
   std::string new_key  = torrent::object_create_string(args.front());
   std::string dest_key = torrent::object_create_string(args.back());
 
-  rpc::commands.create_redirect(create_new_key(new_key), create_new_key(dest_key),
-                                rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_delete_key | rpc::CommandMap::flag_modifiable);
+  rpc::commands.create_redirect(create_new_key(new_key),
+                                create_new_key(dest_key),
+                                rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_delete_key |
+                                  rpc::CommandMap::flag_modifiable);
 
   return torrent::Object();
 }
@@ -372,9 +384,9 @@ system_method_has_key(const torrent::Object::list_type& args) {
     throw torrent::input_error("Invalid argument count.");
 
   torrent::Object::list_const_iterator itrArgs = args.begin();
-  const std::string& key = (itrArgs++)->as_string();
-  const std::string& cmd_key = (itrArgs++)->as_string();
-  
+  const std::string&                   key     = (itrArgs++)->as_string();
+  const std::string&                   cmd_key = (itrArgs++)->as_string();
+
   return control->object_storage()->has_str_multi_key(key, cmd_key);
 }
 
@@ -384,9 +396,9 @@ system_method_set_key(const torrent::Object::list_type& args) {
     throw torrent::input_error("Invalid argument count.");
 
   torrent::Object::list_const_iterator itrArgs = args.begin();
-  const std::string& key = (itrArgs++)->as_string();
-  const std::string& cmd_key = (itrArgs++)->as_string();
-  
+  const std::string&                   key     = (itrArgs++)->as_string();
+  const std::string&                   cmd_key = (itrArgs++)->as_string();
+
   if (itrArgs == args.end()) {
     control->object_storage()->erase_str_multi_key(key, cmd_key);
     return torrent::Object();
@@ -403,9 +415,9 @@ system_method_set_key(const torrent::Object::list_type& args) {
 torrent::Object
 system_method_list_keys(const torrent::Object::string_type& args) {
   const torrent::Object::map_type& multi_cmd = control->object_storage()->get_str(args).as_map();
-  
-  torrent::Object rawResult = torrent::Object::create_list();
-  torrent::Object::list_type& result = rawResult.as_list();
+
+  torrent::Object                  rawResult = torrent::Object::create_list();
+  torrent::Object::list_type&      result    = rawResult.as_list();
 
   for (torrent::Object::map_const_iterator itr = multi_cmd.begin(), last = multi_cmd.end(); itr != last; itr++)
     result.push_back(itr->first);
@@ -423,11 +435,11 @@ cmd_catch(rpc::target_type target, const torrent::Object& args) {
   }
 }
 
-#define CMD2_METHOD_INSERT(key, flags) \
-  CMD2_ANY_LIST(key, std::bind(&system_method_insert_object, std::placeholders::_2, flags));
+#define CMD2_METHOD_INSERT(key, flags) CMD2_ANY_LIST(key, std::bind(&system_method_insert_object, std::placeholders::_2, flags));
 
 void
 initialize_command_dynamic() {
+  // clang-format off
   CMD2_VAR_BOOL    ("method.use_deprecated", true);
   CMD2_VAR_VALUE   ("method.use_intermediate", 1);
 
@@ -472,4 +484,5 @@ initialize_command_dynamic() {
   CMD2_ANY         ("strings.log_group",                 std::bind(&torrent::option_list_strings, torrent::OPTION_LOG_GROUP));
   CMD2_ANY         ("strings.tracker_event",             std::bind(&torrent::option_list_strings, torrent::OPTION_TRACKER_EVENT));
   CMD2_ANY         ("strings.tracker_mode",              std::bind(&torrent::option_list_strings, torrent::OPTION_TRACKER_MODE));
+  // clang-format on
 }

--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -46,17 +46,18 @@
 #include "rpc/parse.h"
 #include "rpc/parse_options.h"
 
-static std::vector<std::pair<const char*, int>> object_storage_flags = {{"multi", rpc::object_storage::flag_multi_type},
-                                                                        {"simple", rpc::object_storage::flag_function_type},
-                                                                        {"value", rpc::object_storage::flag_value_type},
-                                                                        {"bool", rpc::object_storage::flag_bool_type},
-                                                                        {"string", rpc::object_storage::flag_string_type},
-                                                                        {"list", rpc::object_storage::flag_list_type},
+static std::vector<std::pair<const char*, int>> object_storage_flags = {
+  {"multi", rpc::object_storage::flag_multi_type},
+  {"simple", rpc::object_storage::flag_function_type},
+  {"value", rpc::object_storage::flag_value_type},
+  {"bool", rpc::object_storage::flag_bool_type},
+  {"string", rpc::object_storage::flag_string_type},
+  {"list", rpc::object_storage::flag_list_type},
 
-                                                                        {"static", rpc::object_storage::flag_static},
-                                                                        {"private", rpc::object_storage::flag_private},
-                                                                        {"const", rpc::object_storage::flag_constant},
-                                                                        {"rlookup", rpc::object_storage::flag_rlookup}};
+  {"static", rpc::object_storage::flag_static},
+  {"private", rpc::object_storage::flag_private},
+  {"const", rpc::object_storage::flag_constant},
+  {"rlookup", rpc::object_storage::flag_rlookup}};
 
 static int
 object_storage_parse_flag(const std::string& flag) {
@@ -82,9 +83,7 @@ system_method_generate_command(torrent::Object::list_const_iterator first, torre
 }
 
 void
-system_method_generate_command2(torrent::Object*                     object,
-                                torrent::Object::list_const_iterator first,
-                                torrent::Object::list_const_iterator last) {
+system_method_generate_command2(torrent::Object* object, torrent::Object::list_const_iterator first, torrent::Object::list_const_iterator last) {
   if (first == last) {
     // TODO: Use empty object.
     *object = "";
@@ -196,8 +195,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
 
     rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type>>::type>(
       create_new_key(rawKey),
-      std::bind(
-        &rpc::object_storage::call_function_str, control->object_storage(), rawKey, std::placeholders::_1, std::placeholders::_2),
+      std::bind(&rpc::object_storage::call_function_str, control->object_storage(), rawKey, std::placeholders::_1, std::placeholders::_2),
       &rpc::command_base_call<rpc::target_type>,
       cmd_flags,
       NULL,
@@ -312,11 +310,14 @@ system_method_insert(const torrent::Object::list_type& args) {
   torrent::Object::list_type new_args;
   new_args.push_back(rawKey);
 
-  if ((new_flags & rpc::object_storage::flag_function_type) || (new_flags & rpc::object_storage::flag_multi_type)) {
+  if ((new_flags & rpc::object_storage::flag_function_type) ||
+      (new_flags & rpc::object_storage::flag_multi_type)) {
     new_args.push_back(system_method_generate_command(++itrArgs, args.end()));
 
-  } else if ((new_flags & rpc::object_storage::flag_value_type) || (new_flags & rpc::object_storage::flag_bool_type) ||
-             (new_flags & rpc::object_storage::flag_string_type) || (new_flags & rpc::object_storage::flag_list_type)) {
+  } else if ((new_flags & rpc::object_storage::flag_value_type) ||
+             (new_flags & rpc::object_storage::flag_bool_type) ||
+             (new_flags & rpc::object_storage::flag_string_type) ||
+             (new_flags & rpc::object_storage::flag_list_type)) {
     if (++itrArgs != args.end())
       new_args.insert(new_args.end(), itrArgs, args.end());
 
@@ -355,10 +356,7 @@ system_method_redirect(const torrent::Object::list_type& args) {
   std::string new_key  = torrent::object_create_string(args.front());
   std::string dest_key = torrent::object_create_string(args.back());
 
-  rpc::commands.create_redirect(create_new_key(new_key),
-                                create_new_key(dest_key),
-                                rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_delete_key |
-                                  rpc::CommandMap::flag_modifiable);
+  rpc::commands.create_redirect(create_new_key(new_key), create_new_key(dest_key), rpc::CommandMap::flag_public_xmlrpc | rpc::CommandMap::flag_delete_key | rpc::CommandMap::flag_modifiable);
 
   return torrent::Object();
 }
@@ -435,7 +433,8 @@ cmd_catch(rpc::target_type target, const torrent::Object& args) {
   }
 }
 
-#define CMD2_METHOD_INSERT(key, flags) CMD2_ANY_LIST(key, std::bind(&system_method_insert_object, std::placeholders::_2, flags));
+#define CMD2_METHOD_INSERT(key, flags) \
+  CMD2_ANY_LIST(key, std::bind(&system_method_insert_object, std::placeholders::_2, flags));
 
 void
 initialize_command_dynamic() {

--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -55,7 +55,8 @@ namespace core {
 
 // Also add focus thingie here?
 struct view_downloads_compare : std::binary_function<Download*, Download*, bool> {
-  view_downloads_compare(const torrent::Object& cmd) : m_command(cmd) {}
+  view_downloads_compare(const torrent::Object& cmd) :
+      m_command(cmd) {}
 
   bool operator()(Download* d1, Download* d2) const {
     try {
@@ -75,8 +76,7 @@ struct view_downloads_compare : std::binary_function<Download*, Download*, bool>
       // return rpc::commands.call_command(tmp_command.as_dict_key().c_str(), tmp_command.as_dict_obj(),
       //                                   rpc::make_target_pair(d1, d2)).as_value();
 
-      return rpc::commands.call_command(m_command.as_dict_key().c_str(), m_command.as_dict_obj(), rpc::make_target_pair(d1, d2))
-        .as_value();
+      return rpc::commands.call_command(m_command.as_dict_key().c_str(), m_command.as_dict_obj(), rpc::make_target_pair(d1, d2)).as_value();
 
     } catch (torrent::input_error& e) {
       control->core()->push_log(e.what());
@@ -89,9 +89,12 @@ struct view_downloads_compare : std::binary_function<Download*, Download*, bool>
 };
 
 struct view_downloads_filter : std::unary_function<Download*, bool> {
-  view_downloads_filter(const torrent::Object& cmd, const torrent::Object& cmd2) : m_command(cmd), m_command2(cmd2) {}
+  view_downloads_filter(const torrent::Object& cmd, const torrent::Object& cmd2) :
+      m_command(cmd), m_command2(cmd2) {}
 
-  bool operator()(Download* d1) const { return this->evalCmd(m_command, d1) && this->evalCmd(m_command2, d1); }
+  bool operator()(Download* d1) const {
+    return this->evalCmd(m_command, d1) && this->evalCmd(m_command2, d1);
+  }
 
   bool evalCmd(const torrent::Object& cmd, Download* d1) const {
     if (cmd.is_empty())
@@ -269,9 +272,8 @@ View::filter() {
     return;
 
   // Parition the list in two steps so we know which elements changed.
-  iterator splitVisible = std::stable_partition(begin_visible(), end_visible(), view_downloads_filter(m_filter, m_temp_filter));
-  iterator splitFiltered =
-    std::stable_partition(begin_filtered(), end_filtered(), view_downloads_filter(m_filter, m_temp_filter));
+  iterator  splitVisible  = std::stable_partition(begin_visible(), end_visible(), view_downloads_filter(m_filter, m_temp_filter));
+  iterator  splitFiltered = std::stable_partition(begin_filtered(), end_filtered(), view_downloads_filter(m_filter, m_temp_filter));
 
   base_type changed(splitVisible, splitFiltered);
   iterator  splitChanged = changed.begin() + std::distance(splitVisible, end_visible());

--- a/src/core/view.h
+++ b/src/core/view.h
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -64,77 +64,80 @@ class Download;
 
 class View : private std::vector<Download*> {
 public:
-  typedef std::vector<Download*>      base_type;
-  typedef std::function<void ()> slot_void;
-  typedef std::list<slot_void>        signal_void;
+  typedef std::vector<Download*> base_type;
+  typedef std::function<void()>  slot_void;
+  typedef std::list<slot_void>   signal_void;
 
-  using base_type::iterator;
   using base_type::const_iterator;
-  using base_type::reverse_iterator;
   using base_type::const_reverse_iterator;
-  
+  using base_type::iterator;
+  using base_type::reverse_iterator;
+
   using base_type::size_type;
 
   View() {}
   ~View();
 
-  void                initialize(const std::string& name);
+  void               initialize(const std::string& name);
 
-  const std::string&  name() const                            { return m_name; }
+  const std::string& name() const { return m_name; }
 
-  bool                empty_visible() const                   { return m_size == 0; }
+  bool               empty_visible() const { return m_size == 0; }
 
-  size_type           size() const                            { return m_size; }
-  size_type           size_visible() const                    { return m_size; }
-  size_type           size_not_visible() const                { return base_type::size() - m_size; }
+  size_type          size() const { return m_size; }
+  size_type          size_visible() const { return m_size; }
+  size_type          size_not_visible() const { return base_type::size() - m_size; }
 
   // Perhaps this should be renamed?
-  iterator            begin_visible()                         { return begin(); }
-  const_iterator      begin_visible() const                   { return begin(); }
+  iterator       begin_visible() { return begin(); }
+  const_iterator begin_visible() const { return begin(); }
 
-  iterator            end_visible()                           { return begin() + m_size; }
-  const_iterator      end_visible() const                     { return begin() + m_size; }
+  iterator       end_visible() { return begin() + m_size; }
+  const_iterator end_visible() const { return begin() + m_size; }
 
-  iterator            begin_filtered()                        { return begin() + m_size; }
-  const_iterator      begin_filtered() const                  { return begin() + m_size; }
+  iterator       begin_filtered() { return begin() + m_size; }
+  const_iterator begin_filtered() const { return begin() + m_size; }
 
-  iterator            end_filtered()                          { return base_type::end(); }
-  const_iterator      end_filtered() const                    { return base_type::end(); }
+  iterator       end_filtered() { return base_type::end(); }
+  const_iterator end_filtered() const { return base_type::end(); }
 
-  iterator            focus()                                 { return begin() + m_focus; }
-  const_iterator      focus() const                           { return begin() + m_focus; }
-  void                set_focus(iterator itr)                 { m_focus = position(itr); emit_changed(); }
+  iterator       focus() { return begin() + m_focus; }
+  const_iterator focus() const { return begin() + m_focus; }
+  void           set_focus(iterator itr) {
+    m_focus = position(itr);
+    emit_changed();
+  }
 
-  void                insert(Download* download)              { base_type::push_back(download); }
-  void                erase(Download* download);
+  void insert(Download* download) { base_type::push_back(download); }
+  void erase(Download* download);
 
-  void                set_visible(Download* download);
-  void                set_not_visible(Download* download);
+  void set_visible(Download* download);
+  void set_not_visible(Download* download);
 
-  void                next_focus();
-  void                prev_focus();
+  void next_focus();
+  void prev_focus();
 
-  void                sort();
+  void sort();
 
-  void                set_sort_new(const torrent::Object& s)      { m_sortNew = s; }
-  void                set_sort_current(const torrent::Object& s)  { m_sortCurrent = s; }
+  void set_sort_new(const torrent::Object& s) { m_sortNew = s; }
+  void set_sort_current(const torrent::Object& s) { m_sortCurrent = s; }
 
   // Need to explicity trigger filtering.
-  void                filter();
-  void                filter_by(const torrent::Object& condition, base_type& result);
-  void                filter_download(core::Download* download);
+  void                   filter();
+  void                   filter_by(const torrent::Object& condition, base_type& result);
+  void                   filter_download(core::Download* download);
 
   const torrent::Object& get_filter() const { return m_filter; }
-  void                set_filter(const torrent::Object& s) { m_filter = s; }
+  void                   set_filter(const torrent::Object& s) { m_filter = s; }
   const torrent::Object& get_filter_temp() const { return m_temp_filter; }
-  void                set_filter_temp(const torrent::Object& s) { m_temp_filter = s; }
-  void                set_filter_on_event(const std::string& event);
+  void                   set_filter_temp(const torrent::Object& s) { m_temp_filter = s; }
+  void                   set_filter_on_event(const std::string& event);
 
-  void                clear_filter_on();
+  void                   clear_filter_on();
 
-  const torrent::Object& event_added() const                           { return m_event_added; }
-  const torrent::Object& event_removed() const                         { return m_event_removed; }
-  void                   set_event_added(const torrent::Object& cmd)   { m_event_added = cmd; }
+  const torrent::Object& event_added() const { return m_event_added; }
+  const torrent::Object& event_removed() const { return m_event_removed; }
+  void                   set_event_added(const torrent::Object& cmd) { m_event_added = cmd; }
   void                   set_event_removed(const torrent::Object& cmd) { m_event_removed = cmd; }
 
   // The time of the last change to the view, semantics of this is
@@ -143,50 +146,50 @@ public:
   //
   // Currently initialized to rak::timer(), though perhaps we should
   // use cachedTimer.
-  rak::timer          last_changed() const                                 { return m_lastChanged; }
-  void                set_last_changed(const rak::timer& t = ::cachedTime) { m_lastChanged = t; }
+  rak::timer last_changed() const { return m_lastChanged; }
+  void       set_last_changed(const rak::timer& t = ::cachedTime) { m_lastChanged = t; }
 
   // Don't connect any slots until after initialize else it get's
   // triggered when adding the Download's in DownloadList.
-  signal_void&        signal_changed()                        { return m_signal_changed; }
+  signal_void& signal_changed() { return m_signal_changed; }
 
 private:
   View(const View&);
-  void operator = (const View&);
+  void        operator=(const View&);
 
-  void                push_back(Download* d)                  { base_type::push_back(d); }
+  void        push_back(Download* d) { base_type::push_back(d); }
 
-  inline void         insert_visible(Download* d);
-  inline void         erase_internal(iterator itr);
+  inline void insert_visible(Download* d);
+  inline void erase_internal(iterator itr);
 
-  void                emit_changed();
-  void                emit_changed_now();
+  void        emit_changed();
+  void        emit_changed_now();
 
-  size_type           position(const_iterator itr) const      { return itr - begin(); }
+  size_type   position(const_iterator itr) const { return itr - begin(); }
 
   // An received thing for changed status so we can sort and filter.
 
-  std::string         m_name;
+  std::string m_name;
 
-  size_type           m_size;
-  size_type           m_focus;
+  size_type   m_size;
+  size_type   m_focus;
 
   // These should be replaced by a faster non-string command type.
-  torrent::Object     m_sortNew;
-  torrent::Object     m_sortCurrent;
+  torrent::Object    m_sortNew;
+  torrent::Object    m_sortCurrent;
 
-  torrent::Object     m_filter;
-  torrent::Object     m_temp_filter; // Temporary view filter (eg: name based filter)
+  torrent::Object    m_filter;
+  torrent::Object    m_temp_filter; // Temporary view filter (eg: name based filter)
 
-  torrent::Object     m_event_added;
-  torrent::Object     m_event_removed;
+  torrent::Object    m_event_added;
+  torrent::Object    m_event_removed;
 
-  rak::timer          m_lastChanged;
+  rak::timer         m_lastChanged;
 
-  signal_void         m_signal_changed;
-  rak::priority_item  m_delayChanged;
+  signal_void        m_signal_changed;
+  rak::priority_item m_delayChanged;
 };
 
-}
+} // namespace core
 
 #endif


### PR DESCRIPTION
I chose the rules to try and be closest aligned to the existing format, and the three additional files have been `clang-format -i`'d to be representative of the changes it would make across the codebase.

I'm unsure of your opinion on code formatters, so here's my personal quick take:
Advantages:
 * New contributors don't have to figure out the format based on existing code. For me personally, I put in a real effort to try and emulate it, and I still got a lot of things wrong.
 * You'd no longer have the cognitive load of having to correct people using a different style

Disadvantages:
 * Large commits when initially changing the style. This can be somewhat mitigated by only formatting on new changes, instead of the whole codebase at once.
 * It'll never match your personal style perfectly. As a counterpoint, to steal a quote from [Rob Pike](https://x.com/bitfield/status/953395343353315329): clang-format's style is nobody's favorite, but clang-format is everybody's favorite

Even if you decide against it, I've found these rules helpful for catching variable naming convention misses, so hopefully it might serve as a reference for other contributors.