### PR TITLE
Keep a cache of session file data, and only write if changes occur

### DIFF
--- a/src/core/download_store.cc
+++ b/src/core/download_store.cc
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -38,21 +38,21 @@
 
 #include "config.h"
 
-#include <string>
-#include <fstream>
-#include <sstream>
-#include <stdio.h>
 #include <fcntl.h>
-#include <unistd.h>
+#include <fstream>
 #include <rak/error_number.h>
 #include <rak/path.h>
 #include <rak/string_manip.h>
-#include <torrent/utils/resume.h>
-#include <torrent/object.h>
+#include <sstream>
+#include <stdio.h>
+#include <string>
 #include <torrent/exceptions.h>
-#include <torrent/torrent.h>
-#include <torrent/rate.h>
+#include <torrent/object.h>
 #include <torrent/object_stream.h>
+#include <torrent/rate.h>
+#include <torrent/torrent.h>
+#include <torrent/utils/resume.h>
+#include <unistd.h>
 
 #include "utils/directory.h"
 
@@ -104,8 +104,8 @@ DownloadStore::set_path(const std::string& path) {
 bool
 DownloadStore::write_atomic_bencode(Download* d, const std::string& suffix, const torrent::Object& obj, uint32_t skip_mask) {
   std::stringstream output_string;
-  std::string       cache_key = create_write_cache_key(d, suffix);
   std::string       filename  = create_filename(d) + suffix;
+  auto              cache_key = create_write_cache_key(d, suffix);
 
   torrent::object_write_bencode(&output_string, &obj, skip_mask);
   size_t output_hash = std::hash<std::string>{}(output_string.str());
@@ -175,8 +175,8 @@ DownloadStore::save(Download* d, int flags) {
   torrent::Object* rtorrent_base = &d->download()->bencode()->get_key("rtorrent");
 
   // Move this somewhere else?
-  rtorrent_base->insert_key("chunks_done",    d->download()->file_list()->completed_chunks());
-  rtorrent_base->insert_key("chunks_wanted",  d->download()->data()->wanted_chunks());
+  rtorrent_base->insert_key("chunks_done", d->download()->file_list()->completed_chunks());
+  rtorrent_base->insert_key("chunks_wanted", d->download()->data()->wanted_chunks());
   rtorrent_base->insert_key("total_uploaded", d->info()->up_rate()->total());
   rtorrent_base->insert_key("total_downloaded", d->info()->down_rate()->total());
 
@@ -253,7 +253,7 @@ DownloadStore::is_correct_format(const std::string& f) {
   return true;
 }
 
-std::string
+DownloadStore::cache_type::key_type
 DownloadStore::create_write_cache_key(Download* d, const std::string& suffix) {
   return d->info()->hash().str() + suffix;
 }
@@ -263,4 +263,4 @@ DownloadStore::create_filename(Download* d) {
   return m_path + rak::transform_hex(d->info()->hash().begin(), d->info()->hash().end()) + ".torrent";
 }
 
-}
+} // namespace core

--- a/src/core/download_store.h
+++ b/src/core/download_store.h
@@ -5,12 +5,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -43,7 +43,7 @@
 #include "utils/lockfile.h"
 
 namespace utils {
-  class Directory;
+class Directory;
 }
 
 namespace core {
@@ -56,35 +56,35 @@ public:
 
   using cache_type = std::unordered_map<std::string, size_t>;
 
-  bool                is_enabled()                            { return m_lockfile.is_locked(); }
+  bool               is_enabled() { return m_lockfile.is_locked(); }
 
-  void                enable(bool lock);
-  void                disable();
+  void               enable(bool lock);
+  void               disable();
 
-  const std::string&  path() const                            { return m_path; }
-  void                set_path(const std::string& path);
+  const std::string& path() const { return m_path; }
+  void               set_path(const std::string& path);
 
-  bool                save(Download* d, int flags);
-  bool                save_full(Download* d)   { return save(d, 0); }
-  bool                save_resume(Download* d) { return save(d, flag_skip_static); }
-  void                remove(Download* d);
+  bool               save(Download* d, int flags);
+  bool               save_full(Download* d) { return save(d, 0); }
+  bool               save_resume(Download* d) { return save(d, flag_skip_static); }
+  void               remove(Download* d);
 
   // Currently shows all entries in the correct format.
-  utils::Directory    get_formated_entries();
+  utils::Directory get_formated_entries();
 
-  static bool         is_correct_format(const std::string& f);
+  static bool      is_correct_format(const std::string& f);
 
 private:
-  std::string         create_filename(Download* d);
-  std::string         create_write_cache_key(Download* d, const std::string& suffix);
+  std::string          create_filename(Download* d);
+  cache_type::key_type create_write_cache_key(Download* d, const std::string& suffix);
 
-  bool                write_atomic_bencode(Download* d, const std::string& suffix, const torrent::Object& obj, uint32_t skip_mask);
+  bool                 write_atomic_bencode(Download* d, const std::string& suffix, const torrent::Object& obj, uint32_t skip_mask);
 
-  std::string         m_path;
-  utils::Lockfile     m_lockfile;
-  cache_type          m_writeCache;
+  std::string          m_path;
+  utils::Lockfile      m_lockfile;
+  cache_type           m_writeCache;
 };
 
-}
+} // namespace core
 
 #endif

--- a/src/core/download_store.h
+++ b/src/core/download_store.h
@@ -38,6 +38,7 @@
 #define RTORRENT_CORE_DOWNLOAD_STORE_H
 
 #include <string>
+#include <unordered_map>
 
 #include "utils/lockfile.h"
 
@@ -52,6 +53,8 @@ class Download;
 class DownloadStore {
 public:
   static const int flag_skip_static = 0x1;
+
+  using cache_type = std::unordered_map<std::string, size_t>;
 
   bool                is_enabled()                            { return m_lockfile.is_locked(); }
 
@@ -73,11 +76,13 @@ public:
 
 private:
   std::string         create_filename(Download* d);
+  std::string         create_write_cache_key(Download* d, const std::string& suffix);
 
-  bool                write_bencode(const std::string& filename, const torrent::Object& obj, uint32_t skip_mask);
+  bool                write_atomic_bencode(Download* d, const std::string& suffix, const torrent::Object& obj, uint32_t skip_mask);
 
   std::string         m_path;
   utils::Lockfile     m_lockfile;
+  cache_type          m_writeCache;
 };
 
 }


### PR DESCRIPTION
This is mainly in response to https://github.com/rakshasa/rtorrent/issues/1313, but making `session.save` less heavy in general has been something I've thought about, and this approach seemed simpler than trying to mark downloads as dirty or have logic depending on the state as described [here](https://github.com/rakshasa/libtorrent/blob/master/TODO_LONGTERM#L41-L43). The overhead of a cache miss is pretty low, but https://github.com/rakshasa/libtorrent/pull/257 was mainly to make this much more effective for libtorrent_resume files. I'm on the fence about whether this is an elegant use of cache or a terrible hack, so I submit it for your consideration.

It includes two other changes to behavior:
* It's now possible for `.libtorrent_resume` to get updated while `.rtorrent` doesn't. I couldn't think of a scenario where this would be bad, and it would've complicated error handling, but it can be done if desired.
* An `::access()` call is made on a cache hit. This is primarily to support the rare but important use case of being able to restore a session directory entirely from scratch on a running instance (e.g. if someone accidentally deletes it)

Something to consider might be adding an override flag so that `d.save_full_session` and `d.save_resume` can ignore the cache.