### PR TITLE
Fix calls ar directly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_INIT([rtorrent], [0.10.0], [sundell.software@gmail.com])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([scripts])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_PROG_AR
 
 AC_DEFINE([API_VERSION], [10], [api version])
 


### PR DESCRIPTION
See : https://bugs.gentoo.org/943039 and https://github.com/gentoo/gentoo/pull/39256

Toolchain tools called directly cause issue in some environnements (cross-compiling, among others)