### PR TITLE
xmlrpc-tinyxml2 fixes from testing against flood

### DIFF
--- a/src/rpc/xmlrpc_tinyxml2.cc
+++ b/src/rpc/xmlrpc_tinyxml2.cc
@@ -306,7 +306,7 @@ process_document(const tinyxml2::XMLDocument* doc, tinyxml2::XMLPrinter* printer
   }
 
   printer->PushHeader(false, true);
-  printer->OpenElement("methodReponse", true);
+  printer->OpenElement("methodResponse", true);
   printer->OpenElement("params", true);
 
   printer->OpenElement("param", true);
@@ -324,7 +324,7 @@ void
 print_xmlrpc_fault(int faultCode, std::string faultString, tinyxml2::XMLPrinter* printer) {
   printer->PushHeader(false, true);
 
-  printer->OpenElement("methodReponse", true);
+  printer->OpenElement("methodResponse", true);
   printer->OpenElement("fault", true);
   printer->OpenElement("struct", true);
 

--- a/src/rpc/xmlrpc_tinyxml2.cc
+++ b/src/rpc/xmlrpc_tinyxml2.cc
@@ -333,7 +333,7 @@ print_xmlrpc_fault(int faultCode, std::string faultString, tinyxml2::XMLPrinter*
   printer->PushText("faultCode");
   printer->CloseElement(true);
   printer->OpenElement("value", true);
-  printer->OpenElement("int", true);
+  printer->OpenElement("i4", true);
   printer->PushText(faultCode);
   printer->CloseElement(true);
   printer->CloseElement(true);

--- a/src/rpc/xmlrpc_tinyxml2.cc
+++ b/src/rpc/xmlrpc_tinyxml2.cc
@@ -237,8 +237,6 @@ print_object_xml(const torrent::Object& obj, tinyxml2::XMLPrinter* printer) {
 
 
 torrent::Object execute_command(std::string method_name, const tinyxml2::XMLElement* params_element) {
-  if (params_element == nullptr)
-    throw xmlrpc_error(XMLRPC_INTERNAL_ERROR, "invalid parameters: null");
   CommandMap::iterator cmd_itr = commands.find(method_name.c_str());
   if (cmd_itr == commands.end() || !(cmd_itr->second.m_flags & CommandMap::flag_public_xmlrpc)) {
     throw xmlrpc_error(XMLRPC_NO_SUCH_METHOD_ERROR, "method '" + method_name + "' not defined");

--- a/src/rpc/xmlrpc_tinyxml2.cc
+++ b/src/rpc/xmlrpc_tinyxml2.cc
@@ -1,39 +1,3 @@
-// rTorrent - BitTorrent client
-// Copyright (C) 2005-2011, Jari Sundell
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-//
-// In addition, as a special exception, the copyright holders give
-// permission to link the code of portions of this program with the
-// OpenSSL library under certain conditions as described in each
-// individual source file, and distribute linked combinations
-// including the two.
-//
-// You must obey the GNU General Public License in all respects for
-// all of the code used other than OpenSSL.  If you modify file(s)
-// with this exception, you may extend this exception to your version
-// of the file(s), but you are not obligated to do so.  If you do not
-// wish to do so, delete this exception statement from your version.
-// If you delete this exception statement from all source files in the
-// program, then also delete it here.
-//
-// Contact:  Jari Sundell <jaris@ifi.uio.no>
-//
-//           Skomakerveien 33
-//           3185 Skoppum, NORWAY
-
 #include "config.h"
 
 #ifdef HAVE_XMLRPC_TINYXML2
@@ -42,46 +6,47 @@
 #endif
 
 #include <cctype>
-#include <string>
 #include <initializer_list>
+#include <string>
 
 #include <stdlib.h>
 
 #include <rak/string_manip.h>
-#include <torrent/object.h>
 #include <torrent/exceptions.h>
+#include <torrent/object.h>
 
+#include "parse_commands.h"
 #include "rpc/tinyxml2/tinyxml2.h"
 #include "utils/base64.h"
 #include "xmlrpc.h"
-#include "parse_commands.h"
 
 namespace rpc {
 
 // Taken from xmlrpc-c
-const int XMLRPC_INTERNAL_ERROR = -500;
-const int XMLRPC_TYPE_ERROR = -501;
-const int XMLRPC_INDEX_ERROR = -502;
-const int XMLRPC_PARSE_ERROR = -503;
-const int XMLRPC_NETWORK_ERROR = -504;
-const int XMLRPC_TIMEOUT_ERROR = -505;
-const int XMLRPC_NO_SUCH_METHOD_ERROR = -506;
-const int XMLRPC_REQUEST_REFUSED_ERROR = -507;
+const int XMLRPC_INTERNAL_ERROR               = -500;
+const int XMLRPC_TYPE_ERROR                   = -501;
+const int XMLRPC_INDEX_ERROR                  = -502;
+const int XMLRPC_PARSE_ERROR                  = -503;
+const int XMLRPC_NETWORK_ERROR                = -504;
+const int XMLRPC_TIMEOUT_ERROR                = -505;
+const int XMLRPC_NO_SUCH_METHOD_ERROR         = -506;
+const int XMLRPC_REQUEST_REFUSED_ERROR        = -507;
 const int XMLRPC_INTROSPECTION_DISABLED_ERROR = -508;
-const int XMLRPC_LIMIT_EXCEEDED_ERROR = -509;
-const int XMLRPC_INVALID_UTF8_ERROR = -510;
+const int XMLRPC_LIMIT_EXCEEDED_ERROR         = -509;
+const int XMLRPC_INVALID_UTF8_ERROR           = -510;
 
 class xmlrpc_error : public torrent::base_error {
 public:
-  xmlrpc_error(int type, std::string msg) : m_type(type), m_msg(msg) {}
+  xmlrpc_error(int type, std::string msg) :
+      m_type(type), m_msg(msg) {}
   virtual ~xmlrpc_error() throw() {}
 
   virtual int         type() const throw() { return m_type; }
   virtual const char* what() const throw() { return m_msg.c_str(); }
 
 private:
-  int                 m_type;
-  std::string         m_msg;
+  int         m_type;
+  std::string m_msg;
 };
 
 const tinyxml2::XMLElement*
@@ -103,7 +68,7 @@ element_to_int(const tinyxml2::XMLNode* elem) {
   if (elem->FirstChild() == nullptr) {
     throw xmlrpc_error(XMLRPC_TYPE_ERROR, "unable to parse empty integer");
   }
-  auto str = elem->FirstChild()->ToText()->Value();
+  auto str    = elem->FirstChild()->ToText()->Value();
   auto result = std::strtoll(str, &pos, 10);
   if (pos == str || *pos != '\0')
     throw xmlrpc_error(XMLRPC_TYPE_ERROR, "unable to parse integer value");
@@ -119,7 +84,7 @@ xml_value_to_object(const tinyxml2::XMLNode* elem) {
     throw xmlrpc_error(XMLRPC_INTERNAL_ERROR, "received non-value element to convert");
   }
   auto root_element = elem->FirstChild();
-  auto root_type = root_element->Value();
+  auto root_type    = root_element->Value();
   if (std::strncmp(root_type, "string", sizeof("string")) == 0) {
     auto child_element = root_element->FirstChild();
     if (child_element == nullptr) {
@@ -139,9 +104,9 @@ xml_value_to_object(const tinyxml2::XMLNode* elem) {
     }
     throw xmlrpc_error(XMLRPC_TYPE_ERROR, "unknown boolean value: " + boolean_text);
   } else if (std::strncmp(root_type, "array", sizeof("array")) == 0) {
-    auto array_raw = torrent::Object::create_list();
-    auto& array = array_raw.as_list();
-    auto data_element = root_element->ToElement()->FirstChildElement("data");
+    auto  array_raw    = torrent::Object::create_list();
+    auto& array        = array_raw.as_list();
+    auto  data_element = root_element->ToElement()->FirstChildElement("data");
     if (data_element == nullptr)
       throw xmlrpc_error(XMLRPC_PARSE_ERROR, "could not find expected data element in array");
     for (auto child = data_element->FirstChildElement("value"); child; child = child->NextSiblingElement("value")) {
@@ -149,8 +114,8 @@ xml_value_to_object(const tinyxml2::XMLNode* elem) {
     }
     return array_raw;
   } else if (std::strncmp(root_type, "struct", sizeof("struct")) == 0) {
-    auto map_raw = torrent::Object::create_map();
-    auto& map = map_raw.as_map();
+    auto  map_raw = torrent::Object::create_map();
+    auto& map     = map_raw.as_map();
     for (auto child = root_element->FirstChildElement("member"); child; child = child->NextSiblingElement("member")) {
       auto key = child->FirstChildElement("name")->GetText();
       map[key] = std::move(xml_value_to_object(child->FirstChildElement("value")));
@@ -235,15 +200,15 @@ print_object_xml(const torrent::Object& obj, tinyxml2::XMLPrinter* printer) {
   }
 }
 
-
-torrent::Object execute_command(std::string method_name, const tinyxml2::XMLElement* params_element) {
+torrent::Object
+execute_command(std::string method_name, const tinyxml2::XMLElement* params_element) {
   CommandMap::iterator cmd_itr = commands.find(method_name.c_str());
   if (cmd_itr == commands.end() || !(cmd_itr->second.m_flags & CommandMap::flag_public_xmlrpc)) {
     throw xmlrpc_error(XMLRPC_NO_SUCH_METHOD_ERROR, "method '" + method_name + "' not defined");
   }
-  torrent::Object params_raw = torrent::Object::create_list();
-  torrent::Object::list_type& params = params_raw.as_list();
-  rpc::target_type target = rpc::make_target();
+  torrent::Object             params_raw = torrent::Object::create_list();
+  torrent::Object::list_type& params     = params_raw.as_list();
+  rpc::target_type            target     = rpc::make_target();
   if (params_element != nullptr) {
     if (std::strncmp(params_element->Name(), "params", sizeof("params")) == 0) {
       // Parse out the target if available
@@ -284,15 +249,15 @@ process_document(const tinyxml2::XMLDocument* doc, tinyxml2::XMLPrinter* printer
     throw xmlrpc_error(XMLRPC_PARSE_ERROR, "methodCall element not found");
   if (doc->FirstChildElement("methodCall")->FirstChildElement("methodName") == nullptr)
     throw xmlrpc_error(XMLRPC_PARSE_ERROR, "methodName element not found");
-  auto method_name = doc->FirstChildElement("methodCall")->FirstChildElement("methodName")->GetText();
+  auto            method_name = doc->FirstChildElement("methodCall")->FirstChildElement("methodName")->GetText();
   torrent::Object result;
 
   // Add a shim here for system.multicall to allow better code reuse, and
   // because system.multicall is one of the few methods that doesn't take a target
   if (method_name == std::string("system.multicall")) {
-    result = torrent::Object::create_list();
-    auto& result_list = result.as_list();
-    auto parent_elements = element_access(doc->RootElement(), {"params", "param", "value", "array", "data"});
+    result                = torrent::Object::create_list();
+    auto& result_list     = result.as_list();
+    auto  parent_elements = element_access(doc->RootElement(), {"params", "param", "value", "array", "data"});
     for (auto child = parent_elements->FirstChildElement("value"); child; child = child->NextSiblingElement("value")) {
       auto sub_method_name = element_access(child, {"struct", "member", "value", "string"})->GetText();
       // If sub_params ends up a nullptr at the end of this if-chian,
@@ -309,14 +274,14 @@ process_document(const tinyxml2::XMLDocument* doc, tinyxml2::XMLPrinter* printer
         sub_result.as_list().push_back(execute_command(sub_method_name, sub_params));
         result_list.push_back(sub_result);
       } catch (xmlrpc_error& e) {
-        auto fault = torrent::Object::create_map();
+        auto fault                    = torrent::Object::create_map();
         fault.as_map()["faultString"] = e.what();
-        fault.as_map()["faultCode"] = e.type();
+        fault.as_map()["faultCode"]   = e.type();
         result_list.push_back(fault);
       } catch (torrent::local_error& e) {
-        auto fault = torrent::Object::create_map();
+        auto fault                    = torrent::Object::create_map();
         fault.as_map()["faultString"] = e.what();
-        fault.as_map()["faultCode"] = XMLRPC_INTERNAL_ERROR;
+        fault.as_map()["faultCode"]   = XMLRPC_INTERNAL_ERROR;
         result_list.push_back(fault);
       }
     }
@@ -337,7 +302,6 @@ process_document(const tinyxml2::XMLDocument* doc, tinyxml2::XMLPrinter* printer
   printer->CloseElement(true);
   printer->CloseElement(true);
 }
-
 
 void
 print_xmlrpc_fault(int faultCode, std::string faultString, tinyxml2::XMLPrinter* printer) {
@@ -379,7 +343,7 @@ XmlRpc::process(const char* inBuffer, uint32_t length, slot_write slotWrite) {
   if (length > m_sizeLimit) {
     tinyxml2::XMLPrinter printer(nullptr, true, 0);
     print_xmlrpc_fault(XMLRPC_LIMIT_EXCEEDED_ERROR, "Content size exceeds maximum XML-RPC limit", &printer);
-    return slotWrite(printer.CStr(), printer.CStrSize()-1);
+    return slotWrite(printer.CStr(), printer.CStrSize() - 1);
   }
   tinyxml2::XMLDocument doc;
   doc.Parse(inBuffer, length);
@@ -389,29 +353,36 @@ XmlRpc::process(const char* inBuffer, uint32_t length, slot_write slotWrite) {
     // remains.
     tinyxml2::XMLPrinter printer(nullptr, true, 0);
     process_document(&doc, &printer);
-    return slotWrite(printer.CStr(), printer.CStrSize()-1);
+    return slotWrite(printer.CStr(), printer.CStrSize() - 1);
   } catch (xmlrpc_error& e) {
     tinyxml2::XMLPrinter printer(nullptr, true, 0);
     print_xmlrpc_fault(e.type(), e.what(), &printer);
-    return slotWrite(printer.CStr(), printer.CStrSize()-1);
+    return slotWrite(printer.CStr(), printer.CStrSize() - 1);
   } catch (torrent::local_error& e) {
     tinyxml2::XMLPrinter printer(nullptr, true, 0);
     print_xmlrpc_fault(XMLRPC_INTERNAL_ERROR, e.what(), &printer);
-    return slotWrite(printer.CStr(), printer.CStrSize()-1);
+    return slotWrite(printer.CStr(), printer.CStrSize() - 1);
   }
 }
 
-void XmlRpc::initialize() { m_isValid = true; }
-void XmlRpc::cleanup() {}
+void
+XmlRpc::initialize() { m_isValid = true; }
+void
+XmlRpc::cleanup() {}
 
-void XmlRpc::insert_command(const char*, const char*, const char*) {}
-void XmlRpc::set_dialect(int) {}
+void
+XmlRpc::insert_command(const char*, const char*, const char*) {}
+void
+XmlRpc::set_dialect(int) {}
 
-int64_t XmlRpc::size_limit() { return static_cast<int64_t>(m_sizeLimit); }
-void    XmlRpc::set_size_limit(uint64_t size) { m_sizeLimit = size; }
+int64_t
+XmlRpc::size_limit() { return static_cast<int64_t>(m_sizeLimit); }
+void
+XmlRpc::set_size_limit(uint64_t size) { m_sizeLimit = size; }
 
-bool    XmlRpc::is_valid() const { return m_isValid; }
+bool
+XmlRpc::is_valid() const { return m_isValid; }
 
-}
+} // namespace rpc
 
 #endif

--- a/test/rpc/xmlrpc_test.cc
+++ b/test/rpc/xmlrpc_test.cc
@@ -78,7 +78,7 @@ XmlrpcTest::test_invalid_utf8() {
 void
 XmlrpcTest::test_size_limit() {
   std::string input = "<?xml version=\"1.0\"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><string>\xc3\x28</string></value></param></params></methodCall>";
-  std::string expected = "<?xml version=\"1.0\"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-509</int></value></member><member><name>faultString</name><value><string>Content size exceeds maximum XML-RPC limit</string></value></member></struct></fault></methodReponse>";
+  std::string expected = "<?xml version=\"1.0\"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-509</i4></value></member><member><name>faultString</name><value><string>Content size exceeds maximum XML-RPC limit</string></value></member></struct></fault></methodReponse>";
   std::string output;
   m_xmlrpc.set_size_limit(1);
   m_xmlrpc.process(input.c_str(), input.size(), [&output](const char* c, uint32_t l){ output.append(c, l); return true;});

--- a/test/rpc/xmlrpc_test.cc
+++ b/test/rpc/xmlrpc_test.cc
@@ -69,7 +69,7 @@ XmlrpcTest::test_invalid_utf8() {
   // valid UTF-8, but doesn't check strings, and Object strings are
   // just a series of bytes so it reflects just fine.
   std::string input = "<?xml version=\"1.0\"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><string>\xc3\x28</string></value></param></params></methodCall>";
-  std::string expected = "<?xml version=\"1.0\"?><methodReponse><params><param><value><array><value><string>\xc3\x28</string></value></array></value></param></params></methodReponse>";
+  std::string expected = "<?xml version=\"1.0\"?><methodResponse><params><param><value><array><value><string>\xc3\x28</string></value></array></value></param></params></methodResponse>";
   std::string output;
   m_xmlrpc.process(input.c_str(), input.size(), [&output](const char* c, uint32_t l){ output.append(c, l); return true;});
   CPPUNIT_ASSERT_EQUAL(expected, output);
@@ -78,7 +78,7 @@ XmlrpcTest::test_invalid_utf8() {
 void
 XmlrpcTest::test_size_limit() {
   std::string input = "<?xml version=\"1.0\"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><string>\xc3\x28</string></value></param></params></methodCall>";
-  std::string expected = "<?xml version=\"1.0\"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-509</i4></value></member><member><name>faultString</name><value><string>Content size exceeds maximum XML-RPC limit</string></value></member></struct></fault></methodReponse>";
+  std::string expected = "<?xml version=\"1.0\"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-509</i4></value></member><member><name>faultString</name><value><string>Content size exceeds maximum XML-RPC limit</string></value></member></struct></fault></methodResponse>";
   std::string output;
   m_xmlrpc.set_size_limit(1);
   m_xmlrpc.process(input.c_str(), input.size(), [&output](const char* c, uint32_t l){ output.append(c, l); return true;});

--- a/test/rpc/xmlrpc_test_data.txt
+++ b/test/rpc/xmlrpc_test_data.txt
@@ -44,32 +44,32 @@
 
 # Invalid - missing method
 <?xml version="1.0"?><methodCall><methodName>no_such_method</methodName><params><param><value><i4>41</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-506</int></value></member><member><name>faultString</name><value><string>method 'no_such_method' not defined</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-506</i4></value></member><member><name>faultString</name><value><string>method 'no_such_method' not defined</string></value></member></struct></fault></methodReponse>
 
 # Invalid - i4 target
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><i4>41</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-500</int></value></member><member><name>faultString</name><value><string>invalid parameters: target must be a string</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-500</i4></value></member><member><name>faultString</name><value><string>invalid parameters: target must be a string</string></value></member></struct></fault></methodReponse>
 
 # Invalid - empty int tag
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><i4/></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-501</int></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodReponse>
 
 # Invalid - empty int text
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><i4></i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-501</int></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodReponse>
 
 # Invalid - broken XML
 thodCall><methodName>test_a</methodName><params><param><value><i4>41</i4></value></param></params></method
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-503</int></value></member><member><name>faultString</name><value><string>Error=XML_ERROR_PARSING_ELEMENT ErrorID=6 (0x6) Line number=1: XMLElement name=method</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-503</i4></value></member><member><name>faultString</name><value><string>Error=XML_ERROR_PARSING_ELEMENT ErrorID=6 (0x6) Line number=1: XMLElement name=method</string></value></member></struct></fault></methodReponse>
 
 # Invalid - non-integer i4
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><i4>string value</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-501</int></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodReponse>
 
 # Invalid - float i4
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><i4>3.14</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-501</int></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodReponse>
 
 # Invalid - non-boolean boolean
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><boolean>string value</boolean></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><int>-501</int></value></member><member><name>faultString</name><value><string>unknown boolean value: string value</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unknown boolean value: string value</string></value></member></struct></fault></methodReponse>

--- a/test/rpc/xmlrpc_test_data.txt
+++ b/test/rpc/xmlrpc_test_data.txt
@@ -2,6 +2,10 @@
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params></params></methodCall>
 <?xml version="1.0"?><methodResponse><params><param><value><array/></value></param></params></methodResponse>
 
+# Basic call without params
+<?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName></methodCall>
+<?xml version="1.0"?><methodReponse><params><param><value><array/></value></param></params></methodReponse>
+
 # UTF-8 string
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><string>чао</string></value></param></params></methodCall>
 <?xml version="1.0"?><methodResponse><params><param><value><array><value><string>чао</string></value></array></value></param></params></methodResponse>

--- a/test/rpc/xmlrpc_test_data.txt
+++ b/test/rpc/xmlrpc_test_data.txt
@@ -4,7 +4,7 @@
 
 # Basic call without params
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array/></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array/></value></param></params></methodResponse>
 
 # UTF-8 string
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><string>чао</string></value></param></params></methodCall>

--- a/test/rpc/xmlrpc_test_data.txt
+++ b/test/rpc/xmlrpc_test_data.txt
@@ -1,75 +1,75 @@
 # Basic call
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array/></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array/></value></param></params></methodResponse>
 
 # UTF-8 string
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><string>чао</string></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><string>чао</string></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><string>чао</string></value></array></value></param></params></methodResponse>
 
 # emoji string
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><string>😊</string></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><string>😊</string></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><string>😊</string></value></array></value></param></params></methodResponse>
 
 # base64 data (which gets returned as a string)
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><base64>Zm9vYmFy</base64></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><string>foobar</string></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><string>foobar</string></value></array></value></param></params></methodResponse>
 
 # i4 ints
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><i4>41</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><i4>41</i4></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><i4>41</i4></value></array></value></param></params></methodResponse>
 
 # i8 ints
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><i8>2247483647</i8></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><i8>2247483647</i8></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><i8>2247483647</i8></value></array></value></param></params></methodResponse>
 
 # negative i8 ints
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><i8>-2347483647</i8></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><i8>-2347483647</i8></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><i8>-2347483647</i8></value></array></value></param></params></methodResponse>
 
 # Empty array
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><array><data><value><i8>2247483647</i8></value></data></array></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><array><value><i8>2247483647</i8></value></array></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><array><value><i8>2247483647</i8></value></array></value></array></value></param></params></methodResponse>
 
 # Simple array
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><array><data></data></array></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><array/></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><array/></value></array></value></param></params></methodResponse>
 
 # Empty struct
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><struct></struct></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><struct/></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><struct/></value></array></value></param></params></methodResponse>
 
 # Simple struct
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><struct><member><name>lowerBound</name><value><i4>18</i4></value></member><member><name>upperBound</name><value><i4>139</i4></value></member></struct></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><params><param><value><array><value><struct><member><name>lowerBound</name><value><i4>18</i4></value></member><member><name>upperBound</name><value><i4>139</i4></value></member></struct></value></array></value></param></params></methodReponse>
+<?xml version="1.0"?><methodResponse><params><param><value><array><value><struct><member><name>lowerBound</name><value><i4>18</i4></value></member><member><name>upperBound</name><value><i4>139</i4></value></member></struct></value></array></value></param></params></methodResponse>
 
 # Invalid - missing method
 <?xml version="1.0"?><methodCall><methodName>no_such_method</methodName><params><param><value><i4>41</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-506</i4></value></member><member><name>faultString</name><value><string>method 'no_such_method' not defined</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-506</i4></value></member><member><name>faultString</name><value><string>method 'no_such_method' not defined</string></value></member></struct></fault></methodResponse>
 
 # Invalid - i4 target
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><i4>41</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-500</i4></value></member><member><name>faultString</name><value><string>invalid parameters: target must be a string</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-500</i4></value></member><member><name>faultString</name><value><string>invalid parameters: target must be a string</string></value></member></struct></fault></methodResponse>
 
 # Invalid - empty int tag
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><i4/></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodResponse>
 
 # Invalid - empty int text
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><string></string></value></param><param><value><i4></i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse empty integer</string></value></member></struct></fault></methodResponse>
 
 # Invalid - broken XML
 thodCall><methodName>test_a</methodName><params><param><value><i4>41</i4></value></param></params></method
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-503</i4></value></member><member><name>faultString</name><value><string>Error=XML_ERROR_PARSING_ELEMENT ErrorID=6 (0x6) Line number=1: XMLElement name=method</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-503</i4></value></member><member><name>faultString</name><value><string>Error=XML_ERROR_PARSING_ELEMENT ErrorID=6 (0x6) Line number=1: XMLElement name=method</string></value></member></struct></fault></methodResponse>
 
 # Invalid - non-integer i4
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><i4>string value</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodResponse>
 
 # Invalid - float i4
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><i4>3.14</i4></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unable to parse integer value</string></value></member></struct></fault></methodResponse>
 
 # Invalid - non-boolean boolean
 <?xml version="1.0"?><methodCall><methodName>xmlrpc_reflect</methodName><params><param><value><boolean>string value</boolean></value></param></params></methodCall>
-<?xml version="1.0"?><methodReponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unknown boolean value: string value</string></value></member></struct></fault></methodReponse>
+<?xml version="1.0"?><methodResponse><fault><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>unknown boolean value: string value</string></value></member></struct></fault></methodResponse>


### PR DESCRIPTION
It's part of the XML-RPC spec, but some clients only accept i4/i8, which should be supported nearly universally.

Fixes #1330