### PR TITLE
Ensure thread is still active when closing a curl socket

### DIFF
--- a/src/core/curl_socket.cc
+++ b/src/core/curl_socket.cc
@@ -100,7 +100,8 @@ CurlSocket::close() {
   if (m_fileDesc == -1)
     throw torrent::internal_error("CurlSocket::close() m_fileDesc == -1.");
 
-  torrent::main_thread()->poll()->closed(this);
+  if (torrent::is_initialized())
+    torrent::main_thread()->poll()->closed(this);
   m_fileDesc = -1;
 }
 


### PR DESCRIPTION
This seems like a reasonable check since there's no guarantee that the torrent::manager will be non-`NULL` as long as this ordering is preserved:
https://github.com/rakshasa/rtorrent/blob/7e1193acabc4a10417aabdeced60eda9e5621733/src/core/manager.cc#L197-L199

On the other hand, I can only reproduce the issue with IPv6 trackers (on a non-IPv6 enabled network), and there's the possibility of finding a more general IPv6 fix elsewhere.

Fixes https://github.com/rakshasa/rtorrent/issues/1302