### PR TITLE
tinyxml2: in xmlrpc an array must include values in a data element

### DIFF
--- a/src/rpc/xmlrpc_tinyxml2.cc
+++ b/src/rpc/xmlrpc_tinyxml2.cc
@@ -152,11 +152,13 @@ print_object_xml(const torrent::Object& obj, tinyxml2::XMLPrinter* printer) {
     break;
   case torrent::Object::TYPE_LIST:
     printer->OpenElement("array", true);
+    printer->OpenElement("data", true);
     for (const auto& itr : obj.as_list()) {
       printer->OpenElement("value", true);
       print_object_xml(itr, printer);
       printer->CloseElement(true);
     }
+    printer->CloseElement(true);
     printer->CloseElement(true);
     break;
   case torrent::Object::TYPE_MAP:


### PR DESCRIPTION
`tinyxml2` implementation of xmlrpc from https://github.com/rakshasa/rtorrent/pull/1322 does not follow XML-RPC [spec](https://xmlrpc.com/spec.md) concerning array :
> An < array > contains a single < data > element, which can contain any number of < value >s.

This PR adds the `<data>` tag in `<array>`.

Fixes :
- https://github.com/crazy-max/docker-rtorrent-rutorrent/issues/419