### PR TITLE
cleanup: Replace rak::call_delete with lambdas

### DIFF
--- a/rak/functional.h
+++ b/rak/functional.h
@@ -391,19 +391,6 @@ if_then(Cond c, Then t) {
   return if_then_t<Cond, Then>(c, t);
 }
 
-template <typename T>
-struct call_delete : public std::unary_function<T*, void> {
-  void operator () (T* t) {
-    delete t;
-  }
-};
-
-template <typename T>
-inline void
-call_delete_func(T* t) {
-  delete t;
-}
-
 template <typename Operation>
 class bind1st_t : public std::unary_function<typename Operation::second_argument_type, typename Operation::result_type> {
 public:

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -81,7 +81,7 @@ DownloadList::check_contains(Download* d) {
 void
 DownloadList::clear() {
   std::for_each(begin(), end(), std::bind1st(std::mem_fun(&DownloadList::close), this));
-  std::for_each(begin(), end(), rak::call_delete<Download>());
+  std::for_each(begin(), end(), [](Download* d) { delete d; });
 
   base_type::clear();
 }

--- a/src/core/view_manager.cc
+++ b/src/core/view_manager.cc
@@ -55,7 +55,7 @@ namespace core {
 
 void
 ViewManager::clear() {
-  std::for_each(begin(), end(), rak::call_delete<View>());
+  std::for_each(begin(), end(), [](View* v) { delete v; });
 
   base_type::clear();
 }

--- a/src/display/text_element_list.cc
+++ b/src/display/text_element_list.cc
@@ -37,7 +37,6 @@
 #include "config.h"
 
 #include <algorithm>
-#include <rak/functional.h>
 #include <torrent/exceptions.h>
 
 #include "text_element_list.h"
@@ -46,7 +45,7 @@ namespace display {
 
 void
 TextElementList::clear() {
-  std::for_each(begin(), end(), rak::call_delete<TextElement>());
+  std::for_each(begin(), end(), [](TextElement* t) { delete t; });
   base_type::clear();
 }
 

--- a/src/display/window_text.cc
+++ b/src/display/window_text.cc
@@ -37,7 +37,6 @@
 #include "config.h"
 
 #include <algorithm>
-#include <rak/functional.h>
 
 #include "canvas.h"
 #include "utils.h"
@@ -55,7 +54,7 @@ WindowText::WindowText(rpc::target_type target, extent_type margin) :
 
 void
 WindowText::clear() {
-  std::for_each(begin(), end(), rak::call_delete<TextElement>());
+  std::for_each(begin(), end(), [](TextElement* text) { delete text; });
   base_type::clear();
 
   delete m_errorHandler;

--- a/src/main.cc
+++ b/src/main.cc
@@ -50,7 +50,6 @@
 #include <torrent/poll.h>
 #include <torrent/data/chunk_utils.h>
 #include <torrent/utils/log.h>
-#include <rak/functional.h>
 #include <rak/error_number.h>
 
 #ifdef HAVE_BACKTRACE
@@ -136,7 +135,7 @@ load_session_torrents() {
     // Replace with session torrent flag.
     f->set_session(true);
     f->set_init_load(true);
-    f->slot_finished(std::bind(&rak::call_delete_func<core::DownloadFactory>, f));
+    f->slot_finished([f](){ delete f; });
     f->load(entries.path() + first->s_name);
     f->commit();
   }
@@ -151,7 +150,7 @@ load_arg_torrents(char** first, char** last) {
     // Replace with session torrent flag.
     f->set_start(true);
     f->set_init_load(true);
-    f->slot_finished(std::bind(&rak::call_delete_func<core::DownloadFactory>, f));
+    f->slot_finished([f](){ delete f; });
     f->load(*first);
     f->commit();
   }

--- a/src/rpc/command_scheduler.cc
+++ b/src/rpc/command_scheduler.cc
@@ -50,7 +50,7 @@
 namespace rpc {
 
 CommandScheduler::~CommandScheduler() {
-  std::for_each(begin(), end(), rak::call_delete<CommandSchedulerItem>());
+  std::for_each(begin(), end(), [](CommandSchedulerItem* item) { delete item; });
 }
 
 CommandScheduler::iterator

--- a/src/ui/download.cc
+++ b/src/ui/download.cc
@@ -36,7 +36,6 @@
 
 #include "config.h"
 
-#include <rak/functional.h>
 #include <rak/string_manip.h>
 #include <torrent/exceptions.h>
 #include <torrent/chunk_manager.h>
@@ -100,7 +99,7 @@ Download::~Download() {
   if (is_active())
     throw torrent::internal_error("ui::Download::~Download() called on an active object.");
 
-  std::for_each(m_uiArray, m_uiArray + DISPLAY_MAX_SIZE, rak::call_delete<ElementBase>());
+  std::for_each(m_uiArray, m_uiArray + DISPLAY_MAX_SIZE, [](ElementBase* eb) { delete eb; });
 
   delete m_windowDownloadStatus;
 }

--- a/src/ui/download_list.cc
+++ b/src/ui/download_list.cc
@@ -38,7 +38,6 @@
 
 #include <sstream>
 
-#include <rak/functional.h>
 #include <rak/string_manip.h>
 #include <torrent/exceptions.h>
 #include <torrent/torrent.h>
@@ -86,7 +85,7 @@ DownloadList::~DownloadList() {
   if (is_active())
     throw std::logic_error("ui::DownloadList::~DownloadList() called on an active object");
 
-  std::for_each(m_uiArray, m_uiArray + DISPLAY_MAX_SIZE, rak::call_delete<ElementBase>());
+  std::for_each(m_uiArray, m_uiArray + DISPLAY_MAX_SIZE, [](ElementBase* eb) { delete eb; });
 
   delete m_windowLog;
 }


### PR DESCRIPTION
This pull request removes the `rak::call_delete` function and replaces it with lambdas. The `rak/functional.h` wrapper is removed from multiple files as a result. 