### PR TITLE
Don't recommend obsolete option 'safe_sync'.

### DIFF
--- a/doc/old/rtorrent.1
+++ b/doc/old/rtorrent.1
@@ -499,10 +499,6 @@ Number of attempts to check the hash while using the mincore status,
 before forcing. Overworked systems might need lower values to get a
 decent hash checking rate.
 .TP
-\fBsafe_sync = \fIyes|no\fB\fR
-Always use MS_SYNC rather than MS_ASYNC when syncing chunks. This may
-be nessesary in case of filesystem bugs like NFS in linux ~2.6.13.
-.TP
 \fBmax_open_files = \fIvalue\fB\fR
 Number of files to simultaneously keep open. LibTorrent dynamically
 opens and closes files as necessary when mapping files to

--- a/doc/old/rtorrent.1.xml
+++ b/doc/old/rtorrent.1.xml
@@ -979,16 +979,6 @@ decent hash checking rate.
       </varlistentry>
 
       <varlistentry>
-        <term>safe_sync = <replaceable>yes|no</replaceable></term>
-        <listitem><para>
-
-Always use MS_SYNC rather than MS_ASYNC when syncing chunks. This may
-be nessesary in case of filesystem bugs like NFS in linux ~2.6.13.
-
-        </para></listitem>
-      </varlistentry>
-
-      <varlistentry>
         <term>max_open_files = <replaceable>value</replaceable></term>
         <listitem><para>
 

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -513,8 +513,8 @@ DownloadList::hash_done(Download* download) {
     if (download->is_done()) {
       confirm_finished(download);
     } else {
-      download->set_message("Hash check on download completion found bad chunks, consider using \"safe_sync\".");
-      lt_log_print(torrent::LOG_TORRENT_ERROR, "Hash check on download completion found bad chunks, consider using \"safe_sync\".");
+      download->set_message("Hash check on download completion found bad chunks.");
+      lt_log_print(torrent::LOG_TORRENT_ERROR, "Hash check on download completion found bad chunks.");
       DL_TRIGGER_EVENT(download, "event.download.hash_final_failed");
     }
 


### PR DESCRIPTION
I got a message recommending <tt>safe_sync</tt> to me while torrenting using NFS. This option no longer appears to exist. Remove it from the diagnostic and the documentation.