### PR TITLE
Fix an FTBFS under -Werror=return-type

### DIFF
--- a/src/rpc/rpc_manager.cc
+++ b/src/rpc/rpc_manager.cc
@@ -115,6 +115,8 @@ RpcManager::process(RPCType type, const char* in_buffer, uint32_t length, slot_r
       return callback(response.c_str(), response.size());
     }
   }
+  default:
+    return false;
   }
 }
 
@@ -139,6 +141,8 @@ RpcManager::is_type_enabled(RPCType type) const {
     return m_is_xmlrpc_enabled;
   case RPCType::JSON:
     return m_is_jsonrpc_enabled;
+  default:
+    return false; /* -Wreturn-type */
   }
 }
 

--- a/src/rpc/rpc_manager.h
+++ b/src/rpc/rpc_manager.h
@@ -42,7 +42,7 @@ public:
   using slot_peer              = std::function<torrent::Peer*(core::Download*, const torrent::HashString&)>;
   using slot_response_callback = std::function<bool(const char*, uint32_t)>;
 
-  enum RPCType { XML,
+  enum class RPCType { XML,
                  JSON };
 
   RpcManager()  = default;


### PR DESCRIPTION
Some Linux distributions globally build with -Werror=return-type, to catch garbage returns from functions. process() could be called with a garbage RPCType value, in which case it would run off the end of the function since there is no `default:` case, and return new garbage.

```
rpc/rpc_manager.cc: In member function ‘bool rpc::RpcManager::process(RPCType, const char*, uint32_t, slot_response_callback)’:
rpc/rpc_manager.cc:119:1: error: control reaches end of non-void function [-Werror=return-type]
  119 | }
rpc/rpc_manager.cc: In member function ‘bool rpc::RpcManager::is_type_enabled(RPCType) const’:
rpc/rpc_manager.cc:143:1: error: control reaches end of non-void function [-Werror=return-type]
  143 | }
```