### PR TITLE
Add RPC set commands to example configs

### DIFF
--- a/doc/rtorrent.rc
+++ b/doc/rtorrent.rc
@@ -73,6 +73,10 @@
 #
 #network.port_random.set = no
 
+# Set RPC type
+#network.rpc.use_xmlrpc.set = true
+#network.rpc.use_jsonrpc.set = true
+
 # Check hash for finished torrents. Might be useful until the bug is
 # fixed that causes lack of disk-space not to be properly reported.
 #

--- a/doc/rtorrent.rc-example
+++ b/doc/rtorrent.rc-example
@@ -76,6 +76,8 @@ schedule2 = monitor_diskspace, 15, 60, ((close_low_diskspace, 1000M))
 ##network.http.capath.set = "/etc/ssl/certs"
 ##network.http.ssl_verify_peer.set = 0
 ##network.http.ssl_verify_host.set = 0
+#network.rpc.use_xmlrpc.set = true
+#network.rpc.use_jsonrpc.set = true
 
 # Some additional values and commands
 method.insert = system.startup_time, value|const, (system.time)


### PR DESCRIPTION
With the addition of JSON-RPC, it may be beneficial to users to disable either RPC format. 

I couldn't find these documented so I have added the config to both example rtorrent.rc files separately so they can be cherrypicked or squashed.