### PR TITLE
convert color_vars to std::array

### DIFF
--- a/src/display/canvas.cc
+++ b/src/display/canvas.cc
@@ -106,7 +106,7 @@ Canvas::build_colors() {
     return;
 
   // basic color names, index maps to ncurses COLOR_*
-  static const char* color_names[] = {
+  static constexpr std::array color_names{
     "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"};
 
   // Those hold the background colors of "odd" and "even"

--- a/src/display/color_map.h
+++ b/src/display/color_map.h
@@ -1,6 +1,7 @@
 #ifndef RTORRENT_DISPLAY_COLOR_MAP_H
 #define RTORRENT_DISPLAY_COLOR_MAP_H
 
+#include <array>
 #include <map>
 
 #include <curses.h>
@@ -26,8 +27,8 @@ enum ColorKind {
   RCOLOR_MAX,
 };
 
-static const char* color_vars[RCOLOR_MAX] = {
-  0,
+static const std::array<const char*, RCOLOR_MAX> color_vars{
+  nullptr,
   "ui.color.title",
   "ui.color.footer",
   "ui.color.focus",


### PR DESCRIPTION
Fixes:

warning: ‘display::color_vars’ defined but not used

Could also add const to it.

Do the same with color_names.