### PR TITLE
use _T sizes for curl

### DIFF
--- a/src/core/curl_get.cc
+++ b/src/core/curl_get.cc
@@ -105,18 +105,18 @@ CurlGet::receive_timeout() {
   return m_stack->transfer_done(m_handle, "Timed out");
 }
 
-double
+curl_off_t
 CurlGet::size_done() {
-  double d = 0.0;
-  curl_easy_getinfo(m_handle, CURLINFO_SIZE_DOWNLOAD, &d);
+  curl_off_t d = 0;
+  curl_easy_getinfo(m_handle, CURLINFO_SIZE_DOWNLOAD_T, &d);
 
   return d;
 }
 
-double
+curl_off_t
 CurlGet::size_total() {
-  double d = 0.0;
-  curl_easy_getinfo(m_handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &d);
+  curl_off_t d = 0;
+  curl_easy_getinfo(m_handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &d);
 
   return d;
 }

--- a/src/core/curl_get.h
+++ b/src/core/curl_get.h
@@ -27,8 +27,8 @@ public:
 
   void               set_active(bool a) { m_active = a; }
 
-  double             size_done();
-  double             size_total();
+  curl_off_t         size_done();
+  curl_off_t         size_total();
 
   CURL*              handle()           { return m_handle; }
 


### PR DESCRIPTION
The non _T are deprecated.