### PR TITLE
  Fix file descriptor leak in session file saving with system.files.session.fdatasync set to no

### DIFF
--- a/src/core/download_store.cc
+++ b/src/core/download_store.cc
@@ -100,8 +100,9 @@ DownloadStore::write_bencode(const std::string& filename, const torrent::Object&
 #else
     fdatasync(fd);
 #endif
-    ::close(fd);
   }
+
+  ::close(fd);
 
   return true;
 


### PR DESCRIPTION
  When system.files.session.fdatasync is set to "no", file descriptors
  were not being closed after writing session files, causing a severe
  resource leak. Each save operation would leak one file descriptor.

  With hundreds of torrents, this leads to tens of thousands of leaked
  file descriptors within hours, mostly pointing to deleted session files.
  This can exhaust the system's file descriptor limit and cause rtorrent
  to fail when opening new files.

  The fix moves the close() call outside the fdatasync conditional block,
  ensuring file descriptors are always properly closed regardless of the
  fdatasync setting.