### PR TITLE
regex: remove std::inheritance

### DIFF
--- a/rak/algorithm.h
+++ b/rak/algorithm.h
@@ -38,7 +38,6 @@
 #define RAK_ALGORITHM_H
 
 #include <algorithm>
-#include <functional>
 #include <limits>
 
 namespace rak {
@@ -115,7 +114,7 @@ advance_backward(_InputIter __first, _InputIter __last, _Distance __distance) {
 }
 
 template <typename _Value>
-struct compare_base : public std::function<bool(_Value, _Value)> {
+struct compare_base {
   bool operator () (const _Value& complete, const _Value& base) const {
     return !complete.compare(0, base.size(), base);
   }

--- a/rak/regex.h
+++ b/rak/regex.h
@@ -50,7 +50,7 @@
 
 namespace rak {
 
-class regex : public std::function<bool (std::string)> {
+class regex {
 public:
   regex() {}
   regex(const std::string& p) : m_pattern(p) {}

--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -16,7 +16,7 @@
 namespace core {
 
 // Also add focus thingie here?
-struct view_downloads_compare : std::function<bool (Download*, Download*)> {
+struct view_downloads_compare {
   view_downloads_compare(const torrent::Object& cmd) :
       m_command(cmd) {}
 
@@ -50,7 +50,7 @@ struct view_downloads_compare : std::function<bool (Download*, Download*)> {
   const torrent::Object& m_command;
 };
 
-struct view_downloads_filter : std::function<bool (Download*)> {
+struct view_downloads_filter {
   view_downloads_filter(const torrent::Object& cmd, const torrent::Object& cmd2) :
       m_command(cmd), m_command2(cmd2) {}
 


### PR DESCRIPTION
Simpler than std::list.

Remove std::function. No need for it.