### PR TITLE
vi/emacs keybind for stopping torrent from download list

### DIFF
--- a/src/ui/element_download_list.cc
+++ b/src/ui/element_download_list.cc
@@ -25,11 +25,11 @@ ElementDownloadList::ElementDownloadList() {
   if (m_view == NULL)
     throw torrent::internal_error("View \"main\" must be present to initialize the main display.");
 
-  m_bindings['\x13'] = std::bind(&ElementDownloadList::receive_command, this, "d.start=");
-  m_bindings['\x04'] = std::bind(&ElementDownloadList::receive_command, this, "branch=d.state=,d.stop=,d.erase=");
-  m_bindings['\x0B'] = std::bind(&ElementDownloadList::receive_command, this, "d.ignore_commands.set=1; d.stop=; d.close=");
-  m_bindings['\x12'] = std::bind(&ElementDownloadList::receive_command, this, "d.complete.set=0; d.check_hash=");
-  m_bindings['\x05'] = std::bind(&ElementDownloadList::receive_command, this, "f.multicall=,f.set_create_queued=0,f.set_resize_queued=0; print=\"Queued create/resize of files in torrent.\"");
+  m_bindings['\x13']   = std::bind(&ElementDownloadList::receive_command, this, "d.start=");
+  m_bindings[KEY_STOP] = m_bindings[control->ui()->navigation_key(RT_KEY_STOP)] = std::bind(&ElementDownloadList::receive_command, this, "branch=d.state=,d.stop=,d.erase=");
+  m_bindings['\x0B']   = std::bind(&ElementDownloadList::receive_command, this, "d.ignore_commands.set=1; d.stop=; d.close=");
+  m_bindings['\x12']   = std::bind(&ElementDownloadList::receive_command, this, "d.complete.set=0; d.check_hash=");
+  m_bindings['\x05']   = std::bind(&ElementDownloadList::receive_command, this, "f.multicall=,f.set_create_queued=0,f.set_resize_queued=0; print=\"Queued create/resize of files in torrent.\"");
 
   m_bindings['+']       = std::bind(&ElementDownloadList::receive_next_priority, this);
   m_bindings['-']       = std::bind(&ElementDownloadList::receive_prev_priority, this);

--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -38,7 +38,8 @@ static const int emacs_keymap[RT_KEYMAP_MAX] = {
   'H' - '@',
   'A' - '@',
   'E' - '@',
-  'L'
+  'L',
+  'D' - '@' // could be null instead to avoid confusion
 };
 
 static const int vi_keymap[RT_KEYMAP_MAX] = {
@@ -52,7 +53,8 @@ static const int vi_keymap[RT_KEYMAP_MAX] = {
   'D' - '@',
   'H',
   'G',
-  'L' - '@'
+  'L' - '@',
+  'x'
 };
 
 Root::Root() {

--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -39,7 +39,7 @@ static const int emacs_keymap[RT_KEYMAP_MAX] = {
   'A' - '@',
   'E' - '@',
   'L',
-  'D' - '@' // could be null instead to avoid confusion
+  'D' - '@'
 };
 
 static const int vi_keymap[RT_KEYMAP_MAX] = {

--- a/src/ui/root.h
+++ b/src/ui/root.h
@@ -35,7 +35,8 @@ enum NavigationKeymap {
   RT_KEY_HOME,
   RT_KEY_END,
   RT_KEY_TOGGLE_LAYOUT,
-  RT_KEYMAP_MAX,
+  RT_KEY_STOP,
+  RT_KEYMAP_MAX
 };
 
 class DownloadList;


### PR DESCRIPTION
Related to PR #1484

I'm not familiar with C++ and I wasn't able to test this since I couldn't get the compiler to find the headers from libtorrent. In theory this PR should make `x` in vi mode the same as `^d`. `C-d` happens to be delete character in emacs, which is the same as the current ncurses binding.