### PR TITLE
lua: Extend `insert_lua_method()`

### DIFF
--- a/lua/rtorrent.lua
+++ b/lua/rtorrent.lua
@@ -64,6 +64,7 @@ end
 -- @param func_name string name of global lua-function
 -- @param ... string list of rtorrent's arguments like `(d.name)` to be
 --                   passed to lua-function when it be called by rtorrent
+--                   NOTE: first one is always target, may be empty string
 rtorrent["insert_lua_method"] = function (name, func_name, ...)
    local args = {}
    for i, v in ipairs({...}) do


### PR DESCRIPTION
## Description

- Document, `insert_lua_method()` that target always passed

- Extend `insert_lua_method()`'s `func_name`'s arguments

  Allows short form with number of arguments and long flexible form with table:
  
  ```lua
  rtorrent.insert_lua_method('d.watch_handler', 'watch_handler', { '$argument.0=' })
  rtorrent.insert_lua_method('d.watch_handler', 'watch_handler', { 0 })
  rtorrent.insert_lua_method('d.watch_handler', 'watch_handler', { [1] = 0 })
  rtorrent.insert_lua_method('d.watch_handler', 'watch_handler', 1)
  rtorrent.insert_lua_method('d.watch_handler', 'watch_handler', 0)
  ```
  
  Also, there are way to pass no arguments at all:
  
  ```lua
  rtorrent.insert_lua_method('d.watch_handler', 'watch_handler')
  ```