### PR TITLE
Remove deprecated no-target flags for commands.

### DIFF
--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -411,7 +411,7 @@ initialize_command_dynamic() {
 
   // Keep these for future use when we deprecate more commands.
   CMD2_VAR_BOOL    ("method.use_deprecated", false);
-  CMD2_VAR_VALUE   ("method.use_intermediate", 0);
+  CMD2_VAR_VALUE   ("method.use_intermediate", 3);
 
   CMD2_ANY_LIST    ("method.insert",             std::bind(&system_method_insert, std::placeholders::_2));
   CMD2_ANY_LIST    ("method.insert.value",       std::bind(&system_method_insert_object, std::placeholders::_2, rpc::object_storage::flag_value_type));

--- a/src/command_events.cc
+++ b/src/command_events.cc
@@ -25,7 +25,7 @@
 torrent::Object
 apply_on_ratio(const torrent::Object& rawArgs) {
   auto& group_name = rawArgs.as_string();
-  auto  view_itr = control->view_manager()->find(rpc::commands.call("group2." + group_name + ".view", rpc::make_target()).as_string());
+  auto  view_itr = control->view_manager()->find(rpc::commands.call("group." + group_name + ".view", rpc::make_target()).as_string());
 
   if (view_itr == control->view_manager()->end())
     throw torrent::input_error("Could not find view.");
@@ -33,9 +33,9 @@ apply_on_ratio(const torrent::Object& rawArgs) {
   // first argument:  minimum ratio to reach
   // second argument: minimum upload amount to reach [optional]
   // third argument:  maximum ratio to reach [optional]
-  int64_t min_ratio  = rpc::commands.call("group2." + group_name + ".ratio.min", rpc::make_target()).as_value();
-  int64_t max_ratio  = rpc::commands.call("group2." + group_name + ".ratio.max", rpc::make_target()).as_value();
-  int64_t min_upload = rpc::commands.call("group2." + group_name + ".ratio.upload", rpc::make_target()).as_value();
+  int64_t min_ratio  = rpc::commands.call("group." + group_name + ".ratio.min", rpc::make_target()).as_value();
+  int64_t max_ratio  = rpc::commands.call("group." + group_name + ".ratio.max", rpc::make_target()).as_value();
+  int64_t min_upload = rpc::commands.call("group." + group_name + ".ratio.upload", rpc::make_target()).as_value();
 
   std::vector<core::Download*> downloads;
 

--- a/src/command_helpers.h
+++ b/src/command_helpers.h
@@ -100,24 +100,19 @@ void initialize_commands();
   CMD2_ANY(key, std::bind(&rpc::command_function_call_object, torrent::Object(torrent::raw_string::from_c_str(cmds)), \
                                std::placeholders::_1, std::placeholders::_2));
 
-#define CMD2_REDIRECT(from_key, to_key) \
+#define CMD2_REDIRECT(from_key, to_key)                                 \
   rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_public_rpc | rpc::CommandMap::flag_dont_delete);
-#define CMD2_REDIRECT_GENERIC(from_key, to_key) \
-  rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_public_rpc | rpc::CommandMap::flag_no_target | rpc::CommandMap::flag_dont_delete);
-#define CMD2_REDIRECT_GENERIC_NO_EXPORT(from_key, to_key) \
-  rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_no_target | rpc::CommandMap::flag_dont_delete);
+#define CMD2_REDIRECT_NO_EXPORT(from_key, to_key)                       \
+  rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_dont_delete);
+#define CMD2_REDIRECT_STR(from_key, to_key)                             \
+  rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_public_rpc;
+#define CMD2_REDIRECT_STR_NO_EXPORT(from_key, to_key)   \
+  rpc::commands.create_redirect(from_key, to_key, 0);
 #define CMD2_REDIRECT_FILE(from_key, to_key) \
   rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_public_rpc | rpc::CommandMap::flag_file_target | rpc::CommandMap::flag_dont_delete);
 #define CMD2_REDIRECT_TRACKER(from_key, to_key) \
   rpc::commands.create_redirect(from_key, to_key, rpc::CommandMap::flag_public_rpc | rpc::CommandMap::flag_tracker_target | rpc::CommandMap::flag_dont_delete);
 
-#define CMD2_REDIRECT_GENERIC_STR(from_key, to_key)                     \
-  rpc::commands.create_redirect(from_key, to_key, \
-                                rpc::CommandMap::flag_public_rpc | rpc::CommandMap::flag_no_target);
-
-#define CMD2_REDIRECT_GENERIC_STR_NO_EXPORT(from_key, to_key)                     \
-  rpc::commands.create_redirect(from_key, to_key, \
-                                rpc::CommandMap::flag_no_target);
 
 //
 // Conversion of return types:

--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -116,34 +116,22 @@ group_insert(const torrent::Object::list_type& args) {
                                                               "schedule_remove2=group." + name + ".ratio"));
   rpc::commands.call("method.insert", rpc::create_object_list("group."  + name + ".ratio.command", "simple",
                                                               "d.try_close= ;d.ignore_commands.set=1"));
-  rpc::commands.call("method.insert", rpc::create_object_list("group2." + name + ".view", "string", view));
-  rpc::commands.call("method.insert", rpc::create_object_list("group2." + name + ".ratio.min", "value", (int64_t)200));
-  rpc::commands.call("method.insert", rpc::create_object_list("group2." + name + ".ratio.max", "value", (int64_t)300));
-  rpc::commands.call("method.insert", rpc::create_object_list("group2." + name + ".ratio.upload", "value", (int64_t)20 << 20));
+  rpc::commands.call("method.insert", rpc::create_object_list("group." + name + ".view", "string", view));
+  rpc::commands.call("method.insert", rpc::create_object_list("group." + name + ".ratio.min", "value", (int64_t)200));
+  rpc::commands.call("method.insert", rpc::create_object_list("group." + name + ".ratio.max", "value", (int64_t)300));
+  rpc::commands.call("method.insert", rpc::create_object_list("group." + name + ".ratio.upload", "value", (int64_t)20 << 20));
 
-  if (rpc::call_command_value("method.use_intermediate") == 1) {
-    // Deprecated in 0.7.0:
+  if (rpc::call_command_value("method.use_intermediate") == 3) {
+    // Cleaned up in 0.16.1:
 
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".view",          "group2." + name + ".view");
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".view.set",      "group2." + name + ".view.set");
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".ratio.min",     "group2." + name + ".ratio.min");
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".ratio.min.set",    "group2." + name + ".ratio.min.set");
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".ratio.max",        "group2." + name + ".ratio.max");
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".ratio.max.set",    "group2." + name + ".ratio.max.set");
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".ratio.upload",     "group2." + name + ".ratio.upload");
-    CMD2_REDIRECT_GENERIC_STR("group." + name + ".ratio.upload.set", "group2." + name + ".ratio.upload.set");
-
-  } if (rpc::call_command_value("method.use_intermediate") == 2) {
-    // Deprecated in 0.7.0:
-
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".view",          "group2." + name + ".view");
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".view.set",      "group2." + name + ".view.set");
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".ratio.min",     "group2." + name + ".ratio.min");
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".ratio.min.set",    "group2." + name + ".ratio.min.set");
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".ratio.max",        "group2." + name + ".ratio.max");
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".ratio.max.set",    "group2." + name + ".ratio.max.set");
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".ratio.upload",     "group2." + name + ".ratio.upload");
-    CMD2_REDIRECT_GENERIC_STR_NO_EXPORT("group." + name + ".ratio.upload.set", "group2." + name + ".ratio.upload.set");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".view",          "group." + name + ".view");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".view.set",      "group." + name + ".view.set");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".ratio.min",     "group." + name + ".ratio.min");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".ratio.min.set",    "group." + name + ".ratio.min.set");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".ratio.max",        "group." + name + ".ratio.max");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".ratio.max.set",    "group." + name + ".ratio.max.set");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".ratio.upload",     "group." + name + ".ratio.upload");
+    CMD2_REDIRECT_STR_NO_EXPORT("group2." + name + ".ratio.upload.set", "group." + name + ".ratio.upload.set");
   }
 
   return name;
@@ -248,7 +236,7 @@ initialize_command_local() {
 
   CMD2_ANY_V       ("system.shutdown.normal",          std::bind(&Control::receive_normal_shutdown, control));
   CMD2_ANY_V       ("system.shutdown.quick",           std::bind(&Control::receive_quick_shutdown, control));
-  CMD2_REDIRECT_GENERIC_NO_EXPORT("system.shutdown", "system.shutdown.normal");
+  CMD2_REDIRECT_NO_EXPORT("system.shutdown", "system.shutdown.normal");
 
   CMD2_ANY         ("system.cwd",                      std::bind(&system_get_cwd));
   CMD2_ANY_STRING  ("system.cwd.set",                  std::bind(&system_set_cwd, std::placeholders::_2));

--- a/src/command_throttle.cc
+++ b/src/command_throttle.cc
@@ -167,10 +167,10 @@ initialize_command_throttle() {
   CMD2_VAR_VALUE   ("throttle.max_downloads.div._val",    1);
   CMD2_VAR_VALUE   ("throttle.max_downloads.global._val", 0);
 
-  CMD2_REDIRECT_GENERIC("throttle.max_uploads.div",      "throttle.max_uploads.div._val");
-  CMD2_REDIRECT_GENERIC("throttle.max_uploads.global",   "throttle.max_uploads.global._val");
-  CMD2_REDIRECT_GENERIC("throttle.max_downloads.div",    "throttle.max_downloads.div._val");
-  CMD2_REDIRECT_GENERIC("throttle.max_downloads.global", "throttle.max_downloads.global._val");
+  CMD2_REDIRECT    ("throttle.max_uploads.div",      "throttle.max_uploads.div._val");
+  CMD2_REDIRECT    ("throttle.max_uploads.global",   "throttle.max_uploads.global._val");
+  CMD2_REDIRECT    ("throttle.max_downloads.div",    "throttle.max_downloads.div._val");
+  CMD2_REDIRECT    ("throttle.max_downloads.global", "throttle.max_downloads.global._val");
 
   CMD2_ANY_VALUE   ("throttle.max_uploads.div.set",      std::bind(&throttle_update, "throttle.max_uploads.div._val.set", std::placeholders::_2));
   CMD2_ANY_VALUE   ("throttle.max_uploads.global.set",   std::bind(&throttle_update, "throttle.max_uploads.global._val.set", std::placeholders::_2));

--- a/src/main.cc
+++ b/src/main.cc
@@ -281,7 +281,7 @@ main(int argc, char** argv) {
        "file.prioritize_toc.first.set = {*.avi,*.mp4,*.mkv,*.gz}\n"
        "file.prioritize_toc.last.set  = {*.zip}\n"
 
-       // Allow setting 'group2.view' as constant, so that we can't
+       // Allow setting 'group.view' as constant, so that we can't
        // modify the value. And look into the possibility of making
        // 'const' use non-heap memory, as we know they can't be
        // erased.
@@ -352,71 +352,71 @@ main(int argc, char** argv) {
     // Functions that might not get depracted as they are nice for
     // configuration files, and thus might do with just some
     // cleanup.
-    CMD2_REDIRECT_GENERIC("upload_rate",   "throttle.global_up.max_rate.set_kb");
-    CMD2_REDIRECT_GENERIC("download_rate", "throttle.global_down.max_rate.set_kb");
+    CMD2_REDIRECT("upload_rate",   "throttle.global_up.max_rate.set_kb");
+    CMD2_REDIRECT("download_rate", "throttle.global_down.max_rate.set_kb");
 
-    CMD2_REDIRECT_GENERIC("ratio.enable",     "group.seeding.ratio.enable");
-    CMD2_REDIRECT_GENERIC("ratio.disable",    "group.seeding.ratio.disable");
-    CMD2_REDIRECT_GENERIC("ratio.min",        "group2.seeding.ratio.min");
-    CMD2_REDIRECT_GENERIC("ratio.max",        "group2.seeding.ratio.max");
-    CMD2_REDIRECT_GENERIC("ratio.upload",     "group2.seeding.ratio.upload");
-    CMD2_REDIRECT_GENERIC("ratio.min.set",    "group2.seeding.ratio.min.set");
-    CMD2_REDIRECT_GENERIC("ratio.max.set",    "group2.seeding.ratio.max.set");
-    CMD2_REDIRECT_GENERIC("ratio.upload.set", "group2.seeding.ratio.upload.set");
+    CMD2_REDIRECT("ratio.enable",     "group.seeding.ratio.enable");
+    CMD2_REDIRECT("ratio.disable",    "group.seeding.ratio.disable");
+    CMD2_REDIRECT("ratio.min",        "group.seeding.ratio.min");
+    CMD2_REDIRECT("ratio.max",        "group.seeding.ratio.max");
+    CMD2_REDIRECT("ratio.upload",     "group.seeding.ratio.upload");
+    CMD2_REDIRECT("ratio.min.set",    "group.seeding.ratio.min.set");
+    CMD2_REDIRECT("ratio.max.set",    "group.seeding.ratio.max.set");
+    CMD2_REDIRECT("ratio.upload.set", "group.seeding.ratio.upload.set");
 
-    CMD2_REDIRECT_GENERIC("encryption", "protocol.encryption.set");
-    CMD2_REDIRECT_GENERIC("encoding_list", "encoding.add");
+    CMD2_REDIRECT("encryption",    "protocol.encryption.set");
+    CMD2_REDIRECT("encoding_list", "encoding.add");
 
-    CMD2_REDIRECT_GENERIC("connection_leech", "protocol.connection.leech.set");
-    CMD2_REDIRECT_GENERIC("connection_seed", "protocol.connection.seed.set");
+    CMD2_REDIRECT("connection_leech", "protocol.connection.leech.set");
+    CMD2_REDIRECT("connection_seed",  "protocol.connection.seed.set");
 
-    CMD2_REDIRECT        ("min_peers", "throttle.min_peers.normal.set");
-    CMD2_REDIRECT        ("max_peers", "throttle.max_peers.normal.set");
-    CMD2_REDIRECT        ("min_peers_seed", "throttle.min_peers.seed.set");
-    CMD2_REDIRECT        ("max_peers_seed", "throttle.max_peers.seed.set");
+    CMD2_REDIRECT("min_peers",      "throttle.min_peers.normal.set");
+    CMD2_REDIRECT("max_peers",      "throttle.max_peers.normal.set");
+    CMD2_REDIRECT("min_peers_seed", "throttle.min_peers.seed.set");
+    CMD2_REDIRECT("max_peers_seed", "throttle.max_peers.seed.set");
 
-    CMD2_REDIRECT        ("min_uploads",   "throttle.min_uploads.set");
-    CMD2_REDIRECT        ("max_uploads",   "throttle.max_uploads.set");
-    CMD2_REDIRECT        ("min_downloads", "throttle.min_downloads.set");
-    CMD2_REDIRECT        ("max_downloads", "throttle.max_downloads.set");
+    CMD2_REDIRECT("min_uploads",   "throttle.min_uploads.set");
+    CMD2_REDIRECT("max_uploads",   "throttle.max_uploads.set");
+    CMD2_REDIRECT("min_downloads", "throttle.min_downloads.set");
+    CMD2_REDIRECT("max_downloads", "throttle.max_downloads.set");
 
-    CMD2_REDIRECT        ("max_uploads_div",      "throttle.max_uploads.div.set");
-    CMD2_REDIRECT        ("max_uploads_global",   "throttle.max_uploads.global.set");
-    CMD2_REDIRECT        ("max_downloads_div",    "throttle.max_downloads.div.set");
-    CMD2_REDIRECT        ("max_downloads_global", "throttle.max_downloads.global.set");
+    CMD2_REDIRECT("max_uploads_div",      "throttle.max_uploads.div.set");
+    CMD2_REDIRECT("max_uploads_global",   "throttle.max_uploads.global.set");
+    CMD2_REDIRECT("max_downloads_div",    "throttle.max_downloads.div.set");
+    CMD2_REDIRECT("max_downloads_global", "throttle.max_downloads.global.set");
 
-    CMD2_REDIRECT_GENERIC("max_memory_usage", "pieces.memory.max.set");
+    CMD2_REDIRECT("max_memory_usage", "pieces.memory.max.set");
 
-    CMD2_REDIRECT        ("bind",       "network.bind_address.set");
-    CMD2_REDIRECT        ("ip",         "network.local_address.set");
-    CMD2_REDIRECT        ("port_range", "network.port_range.set");
+    CMD2_REDIRECT("bind",       "network.bind_address.set");
+    CMD2_REDIRECT("ip",         "network.local_address.set");
+    CMD2_REDIRECT("port_range", "network.port_range.set");
 
-    CMD2_REDIRECT_GENERIC("dht",      "dht.mode.set");
+    CMD2_REDIRECT("dht",        "dht.mode.set");
 
-    CMD2_REDIRECT        ("port_random", "network.port_random.set");
-    CMD2_REDIRECT        ("proxy_address", "network.proxy_address.set");
+    CMD2_REDIRECT("port_random", "network.port_random.set");
+    CMD2_REDIRECT("proxy_address", "network.proxy_address.set");
 
-    CMD2_REDIRECT        ("scgi_port", "network.scgi.open_port");
-    CMD2_REDIRECT        ("scgi_local", "network.scgi.open_local");
+    CMD2_REDIRECT("scgi_port", "network.scgi.open_port");
+    CMD2_REDIRECT("scgi_local", "network.scgi.open_local");
 
-    CMD2_REDIRECT_GENERIC("directory", "directory.default.set");
-    CMD2_REDIRECT_GENERIC("session",   "session.path.set");
+    CMD2_REDIRECT("directory", "directory.default.set");
+    CMD2_REDIRECT("session",   "session.path.set");
 
-    CMD2_REDIRECT        ("check_hash", "pieces.hash.on_completion.set");
+    CMD2_REDIRECT("check_hash", "pieces.hash.on_completion.set");
 
-    CMD2_REDIRECT        ("key_layout", "keys.layout.set");
+    CMD2_REDIRECT("key_layout", "keys.layout.set");
 
-    CMD2_REDIRECT_GENERIC("to_gm_time", "convert.gm_time");
-    CMD2_REDIRECT_GENERIC("to_gm_date", "convert.gm_date");
-    CMD2_REDIRECT_GENERIC("to_time", "convert.time");
-    CMD2_REDIRECT_GENERIC("to_date", "convert.date");
-    CMD2_REDIRECT_GENERIC("to_elapsed_time", "convert.elapsed_time");
-    CMD2_REDIRECT_GENERIC("to_kb", "convert.kb");
-    CMD2_REDIRECT_GENERIC("to_mb", "convert.mb");
-    CMD2_REDIRECT_GENERIC("to_xb", "convert.xb");
-    CMD2_REDIRECT_GENERIC("to_throttle", "convert.throttle");
+    CMD2_REDIRECT("to_gm_time", "convert.gm_time");
+    CMD2_REDIRECT("to_gm_date", "convert.gm_date");
+    CMD2_REDIRECT("to_time", "convert.time");
+    CMD2_REDIRECT("to_date", "convert.date");
+    CMD2_REDIRECT("to_elapsed_time", "convert.elapsed_time");
+    CMD2_REDIRECT("to_kb", "convert.kb");
+    CMD2_REDIRECT("to_mb", "convert.mb");
+    CMD2_REDIRECT("to_xb", "convert.xb");
+    CMD2_REDIRECT("to_throttle", "convert.throttle");
 
-    CMD2_REDIRECT        ("torrent_list_layout", "ui.torrent_list.layout.set");
+    CMD2_REDIRECT("torrent_list_layout", "ui.torrent_list.layout.set");
 
     // Deprecated commands. Don't use these anymore.
     //
@@ -424,17 +424,17 @@ main(int argc, char** argv) {
     // call style, where the first argument is the target.
 
     // if (rpc::call_command_value("method.use_intermediate") == 1) {
-    //   CMD2_REDIRECT_GENERIC("execute", "execute2");
+    //   CMD2_REDIRECT("execute", "execute2");
 
-    //   CMD2_REDIRECT_GENERIC("schedule", "schedule2");
-    //   CMD2_REDIRECT_GENERIC("schedule_remove", "schedule_remove2");
+    //   CMD2_REDIRECT("schedule", "schedule2");
+    //   CMD2_REDIRECT("schedule_remove", "schedule_remove2");
 
     // } else if (rpc::call_command_value("method.use_intermediate") == 2) {
     //   Allow for use in config files, etc, just don't export it.
-    //   CMD2_REDIRECT_GENERIC_NO_EXPORT("execute", "execute2");
+    //   CMD2_REDIRECT_NO_EXPORT("execute", "execute2");
 
-    //   CMD2_REDIRECT_GENERIC_NO_EXPORT("schedule", "schedule2");
-    //   CMD2_REDIRECT_GENERIC_NO_EXPORT("schedule_remove", "schedule_remove2");
+    //   CMD2_REDIRECT_NO_EXPORT("schedule", "schedule2");
+    //   CMD2_REDIRECT_NO_EXPORT("schedule_remove", "schedule_remove2");
     // }
 
     // if (rpc::call_command_value("method.use_deprecated") == 1) {

--- a/src/rpc/command_map.h
+++ b/src/rpc/command_map.h
@@ -53,9 +53,8 @@ public:
   static const int flag_is_redirect   = 0x20;
   static const int flag_has_redirects = 0x40;
 
-  static const int flag_no_target      = 0x100;
-  static const int flag_file_target    = 0x200;
-  static const int flag_tracker_target = 0x400;
+  static const int flag_file_target    = 0x100;
+  static const int flag_tracker_target = 0x200;
 
   CommandMap() = default;
 

--- a/src/rpc/jsonrpc.cc
+++ b/src/rpc/jsonrpc.cc
@@ -122,18 +122,16 @@ jsonrpc_call_command(const std::string& method, const json& params) {
   std::function<void()> deleter = []() {};
   utils::scope_guard    guard([&deleter]() { deleter(); });
 
-  if (!(itr->second.m_flags & CommandMap::flag_no_target)) {
-    // Provide a blank target if none was provided
-    if (params_object_list.empty())
-      params_object_list.push_back("");
+  // Provide a blank target if none was provided
+  if (params_object_list.empty())
+    params_object_list.push_back("");
 
-    if (!params_object_list.begin()->is_string())
-      throw torrent::input_error("invalid parameters: target must be a string");
+  if (!params_object_list.begin()->is_string())
+    throw torrent::input_error("invalid parameters: target must be a string");
 
-    RpcManager::object_to_target(params_object_list.begin()->as_string(), itr->second.m_flags, &target, &deleter);
+  RpcManager::object_to_target(params_object_list.begin()->as_string(), itr->second.m_flags, &target, &deleter);
 
-    params_object_list.erase(params_object_list.begin());
-  }
+  params_object_list.erase(params_object_list.begin());
 
   const auto& result = rpc::commands.call_command(itr, params_object, target);
 

--- a/src/rpc/rpc_manager.cc
+++ b/src/rpc/rpc_manager.cc
@@ -15,9 +15,6 @@ ExecFile   execFile;
 
 void
 RpcManager::object_to_target(const torrent::Object& obj, int call_flags, rpc::target_type* target, std::function<void()>* deleter) {
-  if (call_flags & CommandMap::flag_no_target)
-    return;
-
   if (!obj.is_string())
     throw torrent::input_error("invalid parameters: target must be a string");
 

--- a/src/rpc/xmlrpc_c.cc
+++ b/src/rpc/xmlrpc_c.cc
@@ -375,9 +375,7 @@ xmlrpc_call_command(xmlrpc_env* env, xmlrpc_value* args, void* voidServerInfo) {
     torrent::Object object;
     rpc::target_type target = rpc::make_target();
 
-    if (itr->second.m_flags & CommandMap::flag_no_target)
-      xmlrpc_to_object(env, args, XmlRpc::call_generic, &target, &deleter).swap(object);
-    else if (itr->second.m_flags & CommandMap::flag_file_target)
+    if (itr->second.m_flags & CommandMap::flag_file_target)
       xmlrpc_to_object(env, args, XmlRpc::call_file, &target, &deleter).swap(object);
     else if (itr->second.m_flags & CommandMap::flag_tracker_target)
       xmlrpc_to_object(env, args, XmlRpc::call_tracker, &target, &deleter).swap(object);

--- a/src/rpc/xmlrpc_tinyxml2.cc
+++ b/src/rpc/xmlrpc_tinyxml2.cc
@@ -204,12 +204,10 @@ execute_command(std::string method_name, const tinyxml2::XMLElement* params_elem
       const auto* child = params_element->FirstChildElement("param");
 
       if (child != nullptr) {
-        if (!(cmd_itr->second.m_flags & CommandMap::flag_no_target)) {
-          std::function<void()> deleter = []() {};
+        std::function<void()> deleter = []() {};
 
-          RpcManager::object_to_target(xml_value_to_object(child->FirstChildElement("value")), cmd_itr->second.m_flags, &target, &deleter);
-          child = child->NextSiblingElement("param");
-        }
+        RpcManager::object_to_target(xml_value_to_object(child->FirstChildElement("value")), cmd_itr->second.m_flags, &target, &deleter);
+        child = child->NextSiblingElement("param");
 
         // Parse out any other params
         while (child != nullptr) {
@@ -223,12 +221,10 @@ execute_command(std::string method_name, const tinyxml2::XMLElement* params_elem
       const auto* child = params_element->FirstChildElement("data")->FirstChildElement("value");
 
       if (child != nullptr) {
-        if (!(cmd_itr->second.m_flags & CommandMap::flag_no_target)) {
-          std::function<void()> deleter = []() {};
+        std::function<void()> deleter = []() {};
 
-          RpcManager::object_to_target(xml_value_to_object(child), cmd_itr->second.m_flags, &target, &deleter);
-          child = child->NextSiblingElement("value");
-        }
+        RpcManager::object_to_target(xml_value_to_object(child), cmd_itr->second.m_flags, &target, &deleter);
+        child = child->NextSiblingElement("value");
 
         while (child != nullptr) {
           params.push_back(xml_value_to_object(child));


### PR DESCRIPTION
This cleans up all old no-target commands, and might break RPC calls that still use the old style.