### PR TITLE
fix: replace VLA

### DIFF
--- a/src/display/text_element_string.cc
+++ b/src/display/text_element_string.cc
@@ -50,16 +50,16 @@ TextElementStringBase::print(char* first, char* last, Canvas::attributes_list* a
     return first;
 
   if (m_flags & flag_escape_hex) {
-    char buffer[last - first];
-    char* bufferLast = copy_string(buffer, buffer + (last - first), target);
+    auto buffer = std::make_unique<char[]>(last - first);
+    char* bufferLast = copy_string(buffer.get(), buffer.get() + (last - first), target);
 
-    first = rak::transform_hex(buffer, bufferLast, first, last);
+    first = rak::transform_hex(buffer.get(), bufferLast, first, last);
 
   } else if (m_flags & flag_escape_html) {
-    char buffer[last - first];
-    char* bufferLast = copy_string(buffer, buffer + (last - first), target);
+    auto buffer = std::make_unique<char[]>(last - first);
+    char* bufferLast = copy_string(buffer.get(), buffer.get() + (last - first), target);
 
-    first = rak::copy_escape_html(buffer, bufferLast, first, last);
+    first = rak::copy_escape_html(buffer.get(), bufferLast, first, last);
 
   } else {
     first = copy_string(first, last, target);

--- a/src/rpc/parse.cc
+++ b/src/rpc/parse.cc
@@ -405,12 +405,12 @@ convert_to_value_nothrow(const torrent::Object& src, int64_t* value, int base, i
   case torrent::Object::TYPE_RAW_STRING: {
     const torrent::raw_string& str = src.as_raw_string();
 
-    char buffer[str.size() + 1];
-    std::memcpy(buffer, str.data(), str.size());
+    auto buffer = std::make_unique<char[]>(str.size() + 1);
+    std::memcpy(buffer.get(), str.data(), str.size());
     buffer[str.size()] = '\0';
 
-    return parse_skip_wspace(parse_value(buffer, value, base, unit), buffer + str.size())
-      == buffer + str.size();
+    return parse_skip_wspace(parse_value(buffer.get(), value, base, unit), buffer.get() + str.size())
+      == buffer.get() + str.size();
   }
   case torrent::Object::TYPE_NONE:
     *value = 0;


### PR DESCRIPTION
Avoids -Wvla-cxx-extension warning by using standard C++ container. VLA is not part of standard C++ and causes portability issues.