### PR TITLE
Allow headless build without curses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,12 +40,22 @@ AC_ARG_ENABLE(execinfo,
     AX_EXECINFO
   ])
 
-AX_PTHREAD([], AC_MSG_ERROR([requires pthread]))
-AX_WITH_CURSES
+AC_ARG_ENABLE([headless],
+  AS_HELP_STRING([--enable-headless], [Enable headless build])
+)
+AS_IF([test "x$enable_headless" = "xyes"], [
+  AC_DEFINE([HEADLESS], [1], [headless build])
+  AC_MSG_NOTICE([Enabling HEADLESS build])
+])
+AM_CONDITIONAL([ENABLE_UI], [test "x$enable_headless" != "xyes"])
 
-if test "x$ax_cv_ncursesw" != xyes && test "x$ax_cv_ncurses" != xyes; then
-  AC_MSG_ERROR([requires either NcursesW or Ncurses library])
-fi
+AX_PTHREAD([], AC_MSG_ERROR([requires pthread]))
+AS_IF([test "x$enable_headless" != "xyes"], [
+    AX_WITH_CURSES
+    AS_IF([test "x$ax_cv_ncursesw" != xyes && test "x$ax_cv_ncurses" != xyes], [
+        AC_MSG_ERROR([requires either NcursesW or Ncurses library])
+    ])
+])
 
 PKG_CHECK_MODULES([CPPUNIT], [cppunit],, [no_cppunit="yes"])
 PKG_CHECK_MODULES([DEPENDENCIES], [libtorrent >= 0.16.2])
@@ -57,9 +67,12 @@ AC_LANG_POP(C++)
 TORRENT_WITH_LUA
 TORRENT_WITH_TINYXML2
 
-if test ${with_xmlrpc_c+y} && test ${with_xmlrpc_tinyxml2+y}; then
+AS_IF([test "x$with_xmlrpc_c" = "xyes" && test "x$with_xmlrpc_tinyxml2" = "xyes"], [
   AC_MSG_ERROR([--with-xmlrpc-c and --with-xmlrpc-tinyxml2 cannot be used together. Please choose only one])
-fi
+])
+AS_IF([test "x$with_xmlrpc_c" != "xyes" && test "x$with_xmlrpc_tinyxml2" != "xyes" && test "x$enable_headless" = "xyes"], [
+  AC_MSG_ERROR([--enable-headless without xmlrpc is useless. Please choose --with-xmlrpc-c or --with-xmlrpc-tinyxml2])
+])
 
 AC_DEFINE(USER_AGENT, [std::string(PACKAGE "/" VERSION "/") + torrent::version()], Http user agent)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,27 +4,8 @@ bin_PROGRAMS = rtorrent
 rtorrent_LDADD = libsub_root.a @PTHREAD_LIBS@
 rtorrent_SOURCES = main.cc
 
-libsub_root_a_SOURCES = \
-	core/dht_manager.cc \
-	core/dht_manager.h \
-	core/download.cc \
-	core/download.h \
-	core/download_factory.cc \
-	core/download_factory.h \
-	core/download_list.cc \
-	core/download_list.h \
-	core/download_store.cc \
-	core/download_store.h \
-	core/http_queue.cc \
-	core/http_queue.h \
-	core/manager.cc \
-	core/manager.h \
-	core/range_map.h \
-	core/view.cc \
-	core/view.h \
-	core/view_manager.cc \
-	core/view_manager.h \
-	\
+if ENABLE_UI
+ui_SOURCES = \
 	display/attributes.h \
 	display/canvas.cc \
 	display/canvas.h \
@@ -33,8 +14,6 @@ libsub_root_a_SOURCES = \
 	display/frame.h \
 	display/manager.cc \
 	display/manager.h \
-	display/utils.cc \
-	display/utils.h \
 	display/text_element.h \
 	display/text_element_list.cc \
 	display/text_element_list.h \
@@ -86,6 +65,55 @@ libsub_root_a_SOURCES = \
 	input/text_input.cc \
 	input/text_input.h \
 	\
+	ui/download.cc \
+	ui/download.h \
+	ui/download_list.cc \
+	ui/download_list.h \
+	ui/element_base.h \
+	ui/element_base.cc \
+	ui/element_chunks_seen.cc \
+	ui/element_chunks_seen.h \
+	ui/element_download_list.cc \
+	ui/element_download_list.h \
+	ui/element_file_list.cc \
+	ui/element_file_list.h \
+	ui/element_log_complete.cc \
+	ui/element_log_complete.h \
+	ui/element_menu.cc \
+	ui/element_menu.h \
+	ui/element_peer_list.cc \
+	ui/element_peer_list.h \
+	ui/element_string_list.cc \
+	ui/element_string_list.h \
+	ui/element_text.cc \
+	ui/element_text.h \
+	ui/element_tracker_list.cc \
+	ui/element_tracker_list.h \
+	ui/element_transfer_list.cc \
+	ui/element_transfer_list.h
+endif
+
+libsub_root_a_SOURCES = \
+	core/dht_manager.cc \
+	core/dht_manager.h \
+	core/download.cc \
+	core/download.h \
+	core/download_factory.cc \
+	core/download_factory.h \
+	core/download_list.cc \
+	core/download_list.h \
+	core/download_store.cc \
+	core/download_store.h \
+	core/http_queue.cc \
+	core/http_queue.h \
+	core/manager.cc \
+	core/manager.h \
+	core/range_map.h \
+	core/view.cc \
+	core/view.h \
+	core/view_manager.cc \
+	core/view_manager.h \
+	\
 	rpc/command.h \
 	rpc/command.cc \
 	rpc/command_impl.h \
@@ -125,32 +153,9 @@ libsub_root_a_SOURCES = \
 	rpc/tinyxml2/tinyxml2.cc \
 	rpc/nlohmann/json.h \
 	\
-	ui/download.cc \
-	ui/download.h \
-	ui/download_list.cc \
-	ui/download_list.h \
-	ui/element_base.h \
-	ui/element_base.cc \
-	ui/element_chunks_seen.cc \
-	ui/element_chunks_seen.h \
-	ui/element_download_list.cc \
-	ui/element_download_list.h \
-	ui/element_file_list.cc \
-	ui/element_file_list.h \
-	ui/element_log_complete.cc \
-	ui/element_log_complete.h \
-	ui/element_menu.cc \
-	ui/element_menu.h \
-	ui/element_peer_list.cc \
-	ui/element_peer_list.h \
-	ui/element_string_list.cc \
-	ui/element_string_list.h \
-	ui/element_text.cc \
-	ui/element_text.h \
-	ui/element_tracker_list.cc \
-	ui/element_tracker_list.h \
-	ui/element_transfer_list.cc \
-	ui/element_transfer_list.h \
+	display/utils.cc \
+	display/utils.h \
+	\
 	ui/root.cc \
 	ui/root.h \
 	\
@@ -192,7 +197,8 @@ libsub_root_a_SOURCES = \
 	signal_handler.cc \
 	signal_handler.h \
 	thread_worker.cc \
-	thread_worker.h
-
+	thread_worker.h \
+	\
+	$(ui_SOURCES)
 
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir) -DPACKAGE_DATADIR=\"$(pkgdatadir)\"

--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -232,7 +232,11 @@ initialize_command_local() {
 
   CMD2_ANY_VALUE_V ("system.umask.set",                std::bind(&umask, std::placeholders::_2));
 
+#ifdef HEADLESS
+  CMD2_VAR_BOOL    ("system.daemon",                   true);
+#else
   CMD2_VAR_BOOL    ("system.daemon",                   false);
+#endif
 
   CMD2_ANY_V       ("system.shutdown.normal",          std::bind(&Control::receive_normal_shutdown, control));
   CMD2_ANY_V       ("system.shutdown.quick",           std::bind(&Control::receive_quick_shutdown, control));

--- a/src/command_ui.cc
+++ b/src/command_ui.cc
@@ -9,9 +9,10 @@
 
 #include "core/manager.h"
 #include "core/view_manager.h"
+#ifndef HEADLESS
 #include "display/canvas.h"
+#endif
 #include "ui/root.h"
-#include "ui/download_list.h"
 #include "display/color_map.h"
 #include "rpc/parse.h"
 
@@ -564,18 +565,18 @@ cmd_view_persistent(const torrent::Object::string_type& args) {
 // TODO: These don't need wrapper functions anymore...
 torrent::Object
 cmd_ui_set_view(const torrent::Object::string_type& args) {
-  control->ui()->download_list()->set_current_view(args);
+  control->ui()->cmd_ui_set_view(args);
   return torrent::Object();
 }
 
 torrent::Object
 cmd_ui_current_view() {
-  return control->ui()->download_list()->current_view()->name();
+  return control->ui()->cmd_ui_current_view();
 }
 
 torrent::Object
 cmd_ui_unfocus_download(core::Download* download) {
-  control->ui()->download_list()->unfocus_download(download);
+  control->ui()->cmd_ui_unfocus_download(download);
 
   return torrent::Object();
 }
@@ -769,7 +770,9 @@ torrent::Object
 apply_set_color(int color_id, const torrent::Object::string_type& color_str) {
   control->object_storage()->set_str_string(display::color_vars[color_id], color_str);
 
+#ifndef HEADLESS
   display::Canvas::build_colors();
+#endif
   return torrent::Object();
 }
 

--- a/src/control.cc
+++ b/src/control.cc
@@ -13,6 +13,7 @@
 #include "core/http_queue.h"
 #include "core/manager.h"
 #include "core/view_manager.h"
+#ifndef HEADLESS
 #include "display/canvas.h"
 #include "display/window.h"
 #include "display/window_http_queue.h"
@@ -22,6 +23,7 @@
 #include "display/manager.h"
 #include "input/manager.h"
 #include "input/input_event.h"
+#endif
 #include "rpc/command_scheduler.h"
 #include "rpc/lua.h"
 #include "rpc/parse_commands.h"
@@ -30,9 +32,11 @@
 
 Control::Control()
   : m_ui(new ui::Root()),
+#ifndef HEADLESS
     m_display(new display::Manager()),
     m_input(new input::Manager()),
     m_inputStdin(new input::InputEvent(STDIN_FILENO)),
+#endif
     m_commandScheduler(new rpc::CommandScheduler()),
     m_objectStorage(new rpc::object_storage()),
     m_lua_engine(new rpc::LuaEngine()),
@@ -42,7 +46,9 @@ Control::Control()
   m_view_manager = std::make_unique<core::ViewManager>();
   m_dht_manager  = std::make_unique<core::DhtManager>();
 
+#ifndef HEADLESS
   m_inputStdin->slot_pressed(std::bind(&input::Manager::pressed, m_input.get(), std::placeholders::_1));
+#endif
 
   m_task_shutdown.slot() = std::bind(&Control::handle_shutdown, this);
 
@@ -53,17 +59,21 @@ Control::~Control() {
   m_view_manager.reset();
 
   m_ui.reset();
+#ifndef HEADLESS
   m_display.reset();
+#endif
 }
 
 void
 Control::initialize() {
   worker_thread->start_thread();
 
+#ifndef HEADLESS
   display::Canvas::initialize();
   display::Window::slot_schedule([this](display::Window* w, std::chrono::microseconds t) { m_display->schedule(w, t); });
   display::Window::slot_unschedule([this](display::Window* w) { m_display->unschedule(w); });
   display::Window::slot_adjust([this]() { m_display->adjust_layout(); });
+#endif
 
   torrent::net_thread::http_stack()->set_user_agent(USER_AGENT);
 
@@ -73,8 +83,10 @@ Control::initialize() {
 
   m_ui->init(this);
 
+#ifndef HEADLESS
   if(!display::Canvas::daemon())
     m_inputStdin->insert(torrent::this_thread::poll());
+#endif
 }
 
 void
@@ -83,23 +95,31 @@ Control::cleanup() {
 
   torrent::this_thread::scheduler()->erase(&m_task_shutdown);
 
+#ifndef HEADLESS
   if(!display::Canvas::daemon())
     m_inputStdin->remove(torrent::this_thread::poll());
+#endif
 
   m_core->download_store()->disable();
 
+#ifndef HEADLESS
   m_ui->cleanup();
+#endif
   m_core->cleanup();
 
+#ifndef HEADLESS
   display::Canvas::erase_std();
   display::Canvas::refresh_std();
   display::Canvas::do_update();
   display::Canvas::cleanup();
+#endif
 }
 
 void
 Control::cleanup_exception() {
+#ifndef HEADLESS
   display::Canvas::cleanup();
+#endif
 }
 
 bool

--- a/src/control.h
+++ b/src/control.h
@@ -1,6 +1,8 @@
 #ifndef RTORRENT_CONTROL_H
 #define RTORRENT_CONTROL_H
 
+#include "config.h"
+
 #include <atomic>
 #include <cinttypes>
 #include <memory>
@@ -61,9 +63,11 @@ public:
   core::DhtManager*   dht_manager()                 { return m_dht_manager.get(); }
 
   ui::Root*           ui()                          { return m_ui.get(); }
+#ifndef HEADLESS
   display::Manager*   display()                     { return m_display.get(); }
   input::Manager*     input()                       { return m_input.get(); }
   input::InputEvent*  input_stdin()                 { return m_inputStdin.get(); }
+#endif
 
   rpc::CommandScheduler* command_scheduler()        { return m_commandScheduler.get(); }
   rpc::object_storage*   object_storage()           { return m_objectStorage.get(); }
@@ -86,9 +90,11 @@ private:
   std::unique_ptr<core::DhtManager>  m_dht_manager;
 
   std::unique_ptr<ui::Root>          m_ui;
+#ifndef HEADLESS
   std::unique_ptr<display::Manager>  m_display;
   std::unique_ptr<input::Manager>    m_input;
   std::unique_ptr<input::InputEvent> m_inputStdin;
+#endif
 
   std::unique_ptr<rpc::CommandScheduler>     m_commandScheduler;
   std::unique_ptr<rpc::object_storage>       m_objectStorage;

--- a/src/ui/root.h
+++ b/src/ui/root.h
@@ -4,11 +4,14 @@
 #include <cstdint>
 #include <memory>
 
+#ifndef HEADLESS
 #include "input/bindings.h"
 #include "download_list.h"
+#endif
 
 class Control;
 
+#ifndef HEADLESS
 namespace display {
   class Frame;
   class WindowTitle;
@@ -19,6 +22,12 @@ namespace display {
 
 namespace input {
   class TextInput;
+}
+#endif
+
+namespace core {
+    class Download;
+    class View;
 }
 
 namespace ui {
@@ -39,12 +48,15 @@ enum NavigationKeymap {
   RT_KEYMAP_MAX
 };
 
+#ifndef HEADLESS
 class DownloadList;
+#endif
 
 typedef std::vector<std::string> ThrottleNameList;
 
 class Root {
 public:
+#ifndef HEADLESS
   typedef display::WindowTitle     WTitle;
   typedef display::WindowHttpQueue WHttpQueue;
   typedef display::WindowInput     WInput;
@@ -53,17 +65,20 @@ public:
   typedef std::map<int, int> InputHistoryPointers;
   typedef std::vector<std::string> InputHistoryCategory;
   typedef std::map<int, InputHistoryCategory> InputHistory;
+#endif
 
   Root();
 
   void                init(Control* c);
   void                cleanup();
 
+#ifndef HEADLESS
   const auto&         window_title() const                    { return m_windowTitle; }
   const auto&         window_statusbar() const                { return m_windowStatusbar; }
   const auto&         window_input() const                    { return m_windowInput; }
 
   const auto&         download_list() const                   { return m_downloadList; }
+#endif
 
   void                set_down_throttle(unsigned int throttle);
   void                set_up_throttle(unsigned int throttle);
@@ -75,7 +90,9 @@ public:
   void                adjust_down_throttle(int throttle);
   void                adjust_up_throttle(int throttle);
 
+#ifndef HEADLESS
   const char*         get_throttle_keys();
+#endif
 
   ThrottleNameList&   get_status_throttle_up_names()          { return m_throttle_up_names; }
   ThrottleNameList&   get_status_throttle_down_names()        { return m_throttle_down_names; }
@@ -83,27 +100,41 @@ public:
   void                set_status_throttle_up_names(const ThrottleNameList& throttle_list)      { m_throttle_up_names = throttle_list; }
   void                set_status_throttle_down_names(const ThrottleNameList& throttle_list)    { m_throttle_down_names = throttle_list; }
 
+#ifdef HEADLESS
+  void                load_input_history() {}
+  void                save_input_history() {}
+  void                clear_input_history() {}
+#else
   void                enable_input(const std::string& title, input::TextInput* input, ui::DownloadList::Input type);
   void                disable_input();
 
   input::TextInput*   current_input();
 
-  int                 get_input_history_size()                { return m_input_history_length; }
-  void                set_input_history_size(int size);
   void                add_to_input_history(ui::DownloadList::Input type, std::string item);
 
   void                load_input_history();
   void                save_input_history();
   void                clear_input_history();
+#endif
+
+  int                 get_input_history_size()                { return m_input_history_length; }
+  void                set_input_history_size(int size);
 
   const std::string&  keymap_style()                          { return m_keymap_style; }
   void                set_keymap_style(const std::string& style);
   const int           navigation_key(NavigationKeymap key);
 
+  void                cmd_ui_set_view(const std::string& name);
+  const std::string&  cmd_ui_current_view();
+  void                cmd_ui_unfocus_download(core::Download* d);
+
 private:
+#ifndef HEADLESS
   void                setup_keys();
+#endif
 
   Control*                      m_control{nullptr};
+#ifndef HEADLESS
   std::unique_ptr<DownloadList> m_downloadList;
 
   std::unique_ptr<WTitle>       m_windowTitle;
@@ -112,8 +143,10 @@ private:
   std::unique_ptr<WStatusbar>   m_windowStatusbar;
 
   input::Bindings      m_bindings;
+#endif
 
   int                  m_input_history_length{99};
+#ifndef HEADLESS
   std::string          m_input_history_last_input{""};
   int                  m_input_history_pointer_get{0};
   InputHistory         m_input_history;
@@ -123,12 +156,17 @@ private:
   void                next_in_input_history(ui::DownloadList::Input type);
 
   void                reset_input_history_attributes(ui::DownloadList::Input type);
+#endif
 
   std::string         m_keymap_style;
   const int*          m_keymap;
 
   ThrottleNameList    m_throttle_up_names;
   ThrottleNameList    m_throttle_down_names;
+
+#ifdef HEADLESS
+  std::string         m_dummyViewName;
+#endif
 };
 
 }


### PR DESCRIPTION
This PR adds a --enable-headless option to configure.

When this option is chosen, most of the sources in the display/, input/ and ui/ subdirs are excluded from the build and the resulting binary is not linked to curses.

There are 2 exceptions from the above:  `display/utils.{cc,h}` and `ui/root.{cc,h}`

In the rest of the code, the preprocessor symbol `HEADLESS` is used to exclude code related to the excluded sources.

### Furthermore:
- The default value of `system.daemon` is `true` to reflect the situation.
- Several `ui.` commands are removed as they don't make sense anymore.

Closes #1613

Cheers
 -Fritz

### Note:
As I am currently unshure, if the disabled `ui.` commands should perhaps implemented as noop dummies (still not making sense to me), I have marked this as draft for now.
Any comments welcome.