### PR TITLE
Changed magnet metadata handling and added 'magnet.path.set'.

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -281,6 +281,9 @@ initialize_command_local() {
 
   CMD2_ANY_V       ("session.save",                    [dList](auto, auto)   { return dList->session_save(); });
 
+  CMD2_ANY         ("magnet.path",                     [](auto, auto)        { return control->core()->magnet_path(); });
+  CMD2_ANY_STRING_V("magnet.path.set",                 [](auto, auto& str)   { return control->core()->set_magnet_path(str); });
+
 #ifdef HAVE_LUA
   rpc::LuaEngine* lua_engine = control->lua_engine();
 

--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -133,6 +133,16 @@ Manager::retrieve_throttle_value(const torrent::Object::string_type& name, bool 
 }
 
 void
+Manager::set_magnet_path(const std::string& path) {
+  if (path.empty())
+    m_magnet_path.clear();
+  else if (path.back() == '/')
+    m_magnet_path = path;
+  else
+    m_magnet_path = path + '/';
+}
+
+void
 Manager::cleanup() {
   // Need to disconnect log signals? Not really since we won't receive
   // any more.

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -61,6 +61,9 @@ public:
 
   void                set_proxy_address(const std::string& addr);
 
+  const std::string&  magnet_path();
+  void                set_magnet_path(const std::string& path);
+
   void                shutdown(bool force);
 
   void                push_log(const char* msg);
@@ -103,10 +106,14 @@ private:
 
   torrent::log_buffer_ptr m_log_important;
   torrent::log_buffer_ptr m_log_complete;
+
+  std::string         m_magnet_path;
 };
 
 // Meh, cleanup.
 extern void receive_tracker_dump(const std::string& url, const char* data, size_t size);
+
+inline const std::string& Manager::magnet_path() { return m_magnet_path; }
 
 }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -45,6 +45,7 @@ void                    cancel_callback(void* target);
 void                    cancel_callback_and_wait(void* target);
 
 session::SessionManager* manager();
+std::string              session_path();
 
 } // namespace torrent::session_thread
 

--- a/src/session/download_storer.cc
+++ b/src/session/download_storer.cc
@@ -92,10 +92,12 @@ DownloadStorer::unlink_files(const std::string& session_path) {
   auto torrent_path    = base_path;
   auto libtorrent_path = base_path + ".libtorrent_resume";
   auto rtorrent_path   = base_path + ".rtorrent";
+  auto metadata_path   = base_path + ".meta";
 
   ::unlink(libtorrent_path.c_str());
   ::unlink(rtorrent_path.c_str());
   ::unlink(torrent_path.c_str());
+  ::unlink(metadata_path.c_str());
 }
 
 namespace {

--- a/src/session/thread_session.cc
+++ b/src/session/thread_session.cc
@@ -82,5 +82,6 @@ void cancel_callback(void* target)                       { session::ThreadSessio
 void cancel_callback_and_wait(void* target)              { session::ThreadSessionInternal::thread_session()->cancel_callback_and_wait(target); }
 
 session::SessionManager* manager()                       { return session::ThreadSessionInternal::thread_session()->manager(); }
+std::string              session_path()                  { return session::ThreadSessionInternal::thread_session()->manager()->path(); }
 
 } // namespace session_thread


### PR DESCRIPTION
When removing a download the session manager also tries to unlink any related `*.meta` file.

However this is only done for magnet metadata files saved to the default path, which is session path.