### PR TITLE
Prevents rtorrent: caught torrent::internal_error: SessionManager::replace_save_request_unsafe() cannot replace full save requests.

### DIFF
--- a/src/session/session_manager.cc
+++ b/src/session/session_manager.cc
@@ -104,8 +104,6 @@ SessionManager::save_full_download(core::Download* download) {
     storer.libtorrent_stream()
   };
 
-  bool should_schedule = false;
-
   {
     std::unique_lock<std::mutex> lock(m_mutex);
 
@@ -116,17 +114,16 @@ SessionManager::save_full_download(core::Download* download) {
 
     if (replace_save_request_unsafe(save_request)) {
       LT_LOG("updated pending save request with full save data : download:%p", download);
-      should_schedule = true;
-    } else {
-      m_save_requests.push_back(std::move(save_request));
-      m_save_request_counter = m_save_requests.size();
-
-      LT_LOG("queued new full save request : download:%p", download);
-      should_schedule = true;
+      return;
     }
+
+    m_save_requests.push_back(std::move(save_request));
+    m_save_request_counter = m_save_requests.size();
+
+    LT_LOG("queued new full save request : download:%p", download);
   }
 
-  if (should_schedule && !m_processing_saves_callback_scheduled.exchange(true))
+  if (!m_processing_saves_callback_scheduled.exchange(true))
     session_thread::callback(this, [this]() { process_save_request(); });
 }
 


### PR DESCRIPTION
Modified `SessionManager::replace_save_request_unsafe()` to return `false` instead of throwing when encountering a full save request