### PR TITLE
dht_add_peer_node is empty, use dht_add_bootstrap_node instead

### DIFF
--- a/src/command_tracker.cc
+++ b/src/command_tracker.cc
@@ -59,7 +59,7 @@ apply_dht_add_node(const std::string& arg) {
       }
 
       lt_log_print(torrent::LOG_DHT_CONTROLLER, "dht.add_node : %s", host_str.c_str());
-      torrent::runtime::network_manager()->dht_add_peer_node(sa.get(), port);
+      torrent::runtime::network_manager()->dht_add_bootstrap_node(host_str.c_str(), port);
   });
 
   return torrent::Object();


### PR DESCRIPTION
After a refactor dht_add_peer_node became empty function. Replace with dht_add_bootstrap_node to make adding bootstrap nodes work.

Related to issue opened in libtorrent - [#646](https://github.com/rakshasa/libtorrent/issues/646)