### PR TITLE
Re-send smkx on SIGWINCH to fix arrow keys after terminal reattach

### DIFF
--- a/src/display/manager.cc
+++ b/src/display/manager.cc
@@ -55,6 +55,7 @@ Manager::receive_update() {
     m_force_redraw = false;
 
     display::Canvas::resize_term(display::Canvas::term_size());
+    keypad(stdscr, TRUE);
     Canvas::redraw_std();
 
     adjust_layout();


### PR DESCRIPTION
When rtorrent is started inside a container in detached mode and later attached, arrow keys and other special keys stop working. This is because the `smkx` (start keypad transmit mode) capability string is only sent once during `initscr()`/`keypad()` at startup, before any terminal is connected.

## Problem

To reproduce:

1. run rtorrent in a docker container in detached mode, `--detach`, so your terminal doesn't immediately connect to it during rtorrent's startup
2. attach to the container with `docker attach` after the fact
3. observe that the arrow keys don't work

To workaround:

1. send the `smkx` string to your terminal by executing `printf "\e[?1h\e="`
2. now attach
3. observe that the arrow keys do work

## Fix

Call `keypad(stdscr, TRUE)` in the SIGWINCH handler path (`Manager::receive_update()`).

The call is idempotent — it has no effect if the terminal is already in application mode.

I confirmed this fix works by building a docker image with it and running it in detached mode, then later attaching.