### PR TITLE
Fix RPC/SCGI security and crash bugs

### DIFF
--- a/src/rpc/jsonrpc.cc
+++ b/src/rpc/jsonrpc.cc
@@ -111,7 +111,7 @@ jsonrpc_call_command(const std::string& method, const json& params) {
 
   CommandMap::iterator itr = commands.find(method.c_str());
 
-  if (itr == commands.end()) {
+  if (itr == commands.end() || !(itr->second.m_flags & CommandMap::flag_public_rpc)) {
     throw rpc_error(JSONRPC_METHOD_NOT_FOUND_ERROR, "method not found: " + method);
   }
 

--- a/src/rpc/lua.cc
+++ b/src/rpc/lua.cc
@@ -211,7 +211,7 @@ object_to_target(const torrent::Object& obj, int call_flags, rpc::target_type* t
         auto tracker = new torrent::tracker::Tracker(rpc.slot_find_tracker()(download, std::stoi(std::string(index))));
 
         *deleter = [tracker]() { delete tracker; };
-        *target = rpc::make_target(command_base::target_tracker, target);
+        *target = rpc::make_target(command_base::target_tracker, tracker);
       }
       break;
 

--- a/src/rpc/object_storage.h
+++ b/src/rpc/object_storage.h
@@ -51,7 +51,7 @@ namespace rpc {
 
 struct object_storage_node {
   torrent::Object object;
-  char            flags;
+  unsigned int    flags;
 };
 
 typedef std::unordered_map<fixed_key_type<64>, object_storage_node, hash_fixed_key_type> object_storage_base_type;

--- a/src/rpc/scgi.cc
+++ b/src/rpc/scgi.cc
@@ -55,7 +55,7 @@ SCgi::open_port(sockaddr* sa, unsigned int length, bool dont_route) {
 
 void
 SCgi::open_named(const std::string& filename) {
-  if (filename.empty() || filename.size() > 4096)
+  if (filename.empty() || filename.size() > sizeof(sockaddr_un::sun_path) - 1)
     throw torrent::resource_error("Invalid filename length.");
 
   auto buffer = std::make_unique<char[]>(sizeof(sockaddr_un) + filename.size() + 1);

--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -136,9 +136,10 @@ SCgiTask::event_read() {
 
       if (strcmp(key, "CONTENT_LENGTH") == 0) {
         char* content_pos;
-        content_length = strtol(value, &content_pos, 10);
-        if (*content_pos != '\0' || content_length <= 0 || content_length > max_content_size)
+        long content_length_raw = strtol(value, &content_pos, 10);
+        if (*content_pos != '\0' || content_length_raw <= 0 || static_cast<size_t>(content_length_raw) > max_content_size)
           goto event_read_failed;
+        content_length = static_cast<size_t>(content_length_raw);
       } else if (strcmp(key, "CONTENT_TYPE") == 0) {
         content_type = value;
       }
@@ -323,8 +324,8 @@ SCgiTask::receive_write(const char* buffer, uint32_t length) {
     realloc_buffer(length + 256, NULL, 0);
 
   const auto header = m_content_type == ContentType::JSON
-                        ? "Status: 200 OK\r\nContent-Type: application/json\r\nContent-Length: %i\r\n\r\n"
-                        : "Status: 200 OK\r\nContent-Type: text/xml\r\nContent-Length: %i\r\n\r\n";
+                        ? "Status: 200 OK\r\nContent-Type: application/json\r\nContent-Length: %u\r\n\r\n"
+                        : "Status: 200 OK\r\nContent-Type: text/xml\r\nContent-Length: %u\r\n\r\n";
 
   // Who ever bothers to check the return value?
   int headerSize = snprintf(m_buffer.get(), m_buffer_size, header, length);

--- a/src/rpc/xmlrpc.cc
+++ b/src/rpc/xmlrpc.cc
@@ -9,7 +9,7 @@
 
 namespace rpc {
 
-std::vector<std::unique_ptr<const char>> XmlRpc::m_command_names;
+std::vector<std::unique_ptr<const char, XmlRpc::free_deleter>> XmlRpc::m_command_names;
 
 const char*
 XmlRpc::store_command_name(const char* name) {
@@ -21,7 +21,7 @@ XmlRpc::store_command_name(const char* name) {
       return itr.get();
   }
 
-  m_command_names.push_back(std::unique_ptr<const char>(::strdup(name)));
+  m_command_names.push_back(std::unique_ptr<const char, free_deleter>(::strdup(name)));
   return m_command_names.back().get();
 }
 

--- a/src/rpc/xmlrpc.h
+++ b/src/rpc/xmlrpc.h
@@ -1,6 +1,7 @@
 #ifndef RTORRENT_RPC_XMLRPC_H
 #define RTORRENT_RPC_XMLRPC_H
 
+#include <cstdlib>
 #include <functional>
 #include <torrent/common.h>
 #include <torrent/hash_string.h>
@@ -61,7 +62,8 @@ public:
 private:
   static const char*  store_command_name(const char* name);
 
-  static std::vector<std::unique_ptr<const char>> m_command_names;
+  struct free_deleter { void operator()(const char* p) const { ::free(const_cast<char*>(p)); } };
+  static std::vector<std::unique_ptr<const char, free_deleter>> m_command_names;
 
   slot_download       m_slotFindDownload;
   slot_file           m_slotFindFile;

--- a/src/rpc/xmlrpc_c.cc
+++ b/src/rpc/xmlrpc_c.cc
@@ -272,6 +272,7 @@ object_to_xmlrpc(xmlrpc_env* env, const torrent::Object& object) {
 #ifdef XMLRPC_HAVE_I8
     if (rpc.dialect() != XmlRpc::dialect_generic)
       return xmlrpc_i8_new(env, object.as_value());
+    return xmlrpc_int_new(env, object.as_value());
 #else
     return xmlrpc_int_new(env, object.as_value());
 #endif

--- a/src/rpc/xmlrpc_tinyxml2.cc
+++ b/src/rpc/xmlrpc_tinyxml2.cc
@@ -71,6 +71,9 @@ xml_value_to_object(const tinyxml2::XMLNode* elem) {
     throw rpc_error(XMLRPC_INTERNAL_ERROR, "received non-value element to convert");
   }
   auto root_element = elem->FirstChild();
+  if (root_element == nullptr) {
+    throw rpc_error(XMLRPC_TYPE_ERROR, "empty value element");
+  }
   auto root_type    = root_element->Value();
   if (std::strncmp(root_type, "string", sizeof("string")) == 0) {
     auto child_element = root_element->FirstChild();
@@ -83,6 +86,9 @@ xml_value_to_object(const tinyxml2::XMLNode* elem) {
              std::strncmp(root_type, "i8", sizeof("i8")) == 0) {
     return torrent::Object(element_to_int(root_element));
   } else if (std::strncmp(root_type, "boolean", sizeof("boolean")) == 0) {
+    if (root_element->FirstChild() == nullptr) {
+      throw rpc_error(XMLRPC_TYPE_ERROR, "unable to parse empty boolean");
+    }
     auto boolean_text = std::string(root_element->FirstChild()->ToText()->Value());
     if (boolean_text == "1") {
       return torrent::Object((int64_t)1);
@@ -104,7 +110,11 @@ xml_value_to_object(const tinyxml2::XMLNode* elem) {
     auto  map_raw = torrent::Object::create_map();
     auto& map     = map_raw.as_map();
     for (auto child = root_element->FirstChildElement("member"); child; child = child->NextSiblingElement("member")) {
-      auto key = child->FirstChildElement("name")->GetText();
+      auto name_element = child->FirstChildElement("name");
+      if (name_element == nullptr) {
+        throw rpc_error(XMLRPC_PARSE_ERROR, "struct member missing name element");
+      }
+      auto key = name_element->GetText();
       map[key] = std::move(xml_value_to_object(child->FirstChildElement("value")));
     }
     return map_raw;


### PR DESCRIPTION
## Summary
- Add missing `flag_public_rpc` check in JSON-RPC, preventing private commands from being callable via JSON-RPC (matches existing XML-RPC behavior)
- Add nullptr checks for empty `<value>`, `<boolean>`, and `<member>` elements in tinyxml2 XML-RPC parser to prevent null pointer dereferences
- Fix signed/unsigned bypass in SCGI `CONTENT_LENGTH` parsing where negative values wrapped to huge positive values
- Reduce Unix socket path limit from 4096 to `sizeof(sun_path)-1` to prevent buffer overflow
- Fix `strdup`/`delete` mismatch (malloc→delete UB) by using a custom `free_deleter` for command names
- Fix wrong pointer (`target`→`tracker`) in Lua RPC tracker target assignment
- Add missing `return` for generic dialect case in xmlrpc-c `TYPE_VALUE` switch (was falling through to `TYPE_STRING`)
- Change `object_storage_node::flags` from `char` (8-bit) to `unsigned int` since flag constants go up to `0x800`
- Fix `%i`→`%u` format for `uint32_t` Content-Length in SCGI response header

## Test plan
- [ ] Verify JSON-RPC rejects private commands (e.g. `system.shutdown`)
- [ ] Send malformed XML-RPC with empty `<value>`, `<boolean>`, `<member>` elements — should get clean error responses instead of crashes
- [ ] Test SCGI with negative CONTENT_LENGTH — should reject the request
- [ ] Verify Unix socket creation with paths near `sizeof(sun_path)` limit
- [ ] Build and run with both `HAVE_XMLRPC_C` and `HAVE_XMLRPC_TINYXML2` configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)