### PR TITLE
Fix core subsystem logic and safety bugs

### DIFF
--- a/src/command_download.cc
+++ b/src/command_download.cc
@@ -46,6 +46,8 @@ retrieve_d_base_filename(core::Download* download) {
 
   if (download->file_list()->is_multi_file())
     base = &download->file_list()->frozen_root_dir();
+  else if (download->file_list()->empty())
+    return std::string();
   else
     base = &download->file_list()->at(0)->frozen_path();
 
@@ -467,12 +469,14 @@ download_tracker_insert(core::Download* download, const torrent::Object::list_ty
   if (args.size() != 2)
     throw torrent::input_error("Wrong argument count.");
 
-  int64_t group;
+  int64_t group = 0;
 
-  if (args.front().is_string())
-    rpc::parse_whole_value_nothrow(args.front().as_string().c_str(), &group);
-  else
+  if (args.front().is_string()) {
+    if (!rpc::parse_whole_value_nothrow(args.front().as_string().c_str(), &group))
+      throw torrent::input_error("Invalid tracker group number.");
+  } else {
     group = args.front().as_value();
+  }
 
   if (group < 0 || group > 32)
     throw torrent::input_error("Tracker group number invalid.");

--- a/src/command_ip.cc
+++ b/src/command_ip.cc
@@ -29,7 +29,7 @@ torrent::Object
 apply_ip_tables_size_data(const std::string& args) {
   rpc::ip_table_list::const_iterator itr = ip_tables.find(args);
 
-  if (itr != ip_tables.end())
+  if (itr == ip_tables.end())
     throw torrent::input_error("IP table does not exist.");
 
   uint32_t size = itr->table.sizeof_data();
@@ -203,9 +203,14 @@ ipv4_range_parse(const char* address, uint32_t* address_start, uint32_t* address
         uint32_t mask=0;
         uint32_t end_mask=0;
 
-        mask = (~mask) << (32-mask_bits);
+        if (mask_bits == 0) {
+          mask = 0;
+          end_mask = ~(uint32_t)0;
+        } else {
+          mask = (~mask) << (32-mask_bits);
+          end_mask = (~end_mask) >> mask_bits;
+        }
         *address_start = ip & mask;
-        end_mask = (~end_mask) >> mask_bits;
         *address_end = (ip & mask) | end_mask;
 
         valid=true;

--- a/src/command_logging.cc
+++ b/src/command_logging.cc
@@ -118,6 +118,9 @@ log_vmmap_dump(const std::string& str) {
 
   FILE* log_file = fopen(str.c_str(), "w");
 
+  if (log_file == NULL)
+    throw torrent::input_error("Could not open log file: " + str);
+
   for (auto& all_mapping : all_mappings) {
     fprintf(log_file, "%8p-%8p [%5llxk]\n", all_mapping.ptr, (char*)all_mapping.ptr + all_mapping.length, (long long unsigned int)(all_mapping.length / 1024));
   }

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <rak/string_manip.h>
@@ -82,6 +83,9 @@ DownloadList::find(const torrent::HashString& hash) {
 
 DownloadList::iterator
 DownloadList::find_hex(const char* hash) {
+  if (strlen(hash) < 40)
+    return end();
+
   torrent::HashString key;
 
   for (torrent::HashString::iterator itr = key.begin(), last = key.end(); itr != last; itr++, hash += 2)

--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -241,9 +241,10 @@ is_data_uri(const std::string& uri) {
 
 std::string
 decode_data_uri(const std::string& uri) {
-  const auto start = uri.find("base64,", 5) + 7;
-  if (start == std::string::npos)
+  const auto pos = uri.find("base64,", 5);
+  if (pos == std::string::npos)
     throw torrent::input_error("Invalid data uri: not base64 encoded.");
+  const auto start = pos + 7;
   if (start >= uri.size())
     throw torrent::input_error("Empty base64.");
   return utils::decode_base64(uri.substr(start));

--- a/src/rpc/parse_commands.cc
+++ b/src/rpc/parse_commands.cc
@@ -258,9 +258,9 @@ command_function_call_object(const torrent::Object& cmd, target_type target, con
     rpc::command_base::pop_stack(&stack, last_stack);
     return result;
 
-  } catch (torrent::bencode_error& e) {
+  } catch (...) {
     rpc::command_base::pop_stack(&stack, last_stack);
-    throw e;
+    throw;
   }
 }
 

--- a/src/signal_handler.cc
+++ b/src/signal_handler.cc
@@ -17,7 +17,7 @@ SignalHandler::slot_void SignalHandler::m_handlers[HIGHEST_SIGNAL];
 
 void
 SignalHandler::set_default(unsigned int signum) {
-  if (signum > HIGHEST_SIGNAL)
+  if (signum >= HIGHEST_SIGNAL)
     throw std::logic_error("SignalHandler::set_default(...) received invalid signal value.");
 
   signal(signum, SIG_DFL);
@@ -26,7 +26,7 @@ SignalHandler::set_default(unsigned int signum) {
 
 void
 SignalHandler::set_ignore(unsigned int signum) {
-  if (signum > HIGHEST_SIGNAL)
+  if (signum >= HIGHEST_SIGNAL)
     throw std::logic_error("SignalHandler::set_ignore(...) received invalid signal value.");
 
   signal(signum, SIG_IGN);
@@ -35,7 +35,7 @@ SignalHandler::set_ignore(unsigned int signum) {
 
 void
 SignalHandler::set_handler(unsigned int signum, slot_void slot) {
-  if (signum > HIGHEST_SIGNAL)
+  if (signum >= HIGHEST_SIGNAL)
     throw std::logic_error("SignalHandler::set_handler(...) received invalid signal value.");
 
   if (!slot)
@@ -54,7 +54,7 @@ SignalHandler::set_handler(unsigned int signum, slot_void slot) {
 
 void
 SignalHandler::set_sigaction_handler(unsigned int signum, handler_slot slot) {
-  if (signum > HIGHEST_SIGNAL)
+  if (signum >= HIGHEST_SIGNAL)
     throw std::logic_error("SignalHandler::set_handler(...) received invalid signal value.");
 
   struct sigaction sa;
@@ -69,7 +69,7 @@ SignalHandler::set_sigaction_handler(unsigned int signum, handler_slot slot) {
 
 void
 SignalHandler::caught(int signum) {
-  if ((unsigned)signum > HIGHEST_SIGNAL)
+  if ((unsigned)signum >= HIGHEST_SIGNAL)
     throw std::logic_error("SignalHandler::caught(...) received invalid signal from the kernel, bork bork bork.");
 
   if (!m_handlers[signum])

--- a/src/utils/base64.cc
+++ b/src/utils/base64.cc
@@ -8,7 +8,7 @@ std::string
 remove_newlines(const std::string& str) {
   std::string result;
   for (auto& itr : str) {
-    if (itr != '\n' || itr != '\n')
+    if (itr != '\n' && itr != '\r')
       result.push_back(itr);
   }
   return result;

--- a/src/utils/directory.cc
+++ b/src/utils/directory.cc
@@ -19,7 +19,9 @@ Directory::is_valid() const {
     return false;
 
   DIR* d = opendir(expand_path(m_path).c_str());
-  closedir(d);
+
+  if (d != NULL)
+    closedir(d);
 
   return d;
 }

--- a/src/utils/list_focus.h
+++ b/src/utils/list_focus.h
@@ -124,12 +124,13 @@ ListFocus<Base>::dec_focus() {
 template <typename Base>
 typename ListFocus<Base>::iterator
 ListFocus<Base>::erase(iterator itr) {
-  if (itr == m_focus)
-    return m_focus = m_base->erase(itr);
-  else
-    return m_base->erase(itr);  
+  if (itr == m_focus) {
+    m_focus = m_base->erase(itr);
+    emit_changed();
+    return m_focus;
+  }
 
-  emit_changed();
+  return m_base->erase(itr);
 }
 
 template <typename Base>


### PR DESCRIPTION
## Summary
- Fix inverted condition in `apply_ip_tables_size_data` that threw when table was found and dereferenced `end()` when not
- Fix always-true condition in `remove_newlines` (`||` should be `&&`, add `\r` check)
- Add NULL `FILE*` check in `log_vmmap_dump` before `fprintf`
- Fix unreachable `emit_changed()` in `ListFocus::erase` by restructuring control flow
- Fix `string::npos + 7` wraparound in `decode_data_uri` by checking `find()` before adding offset
- Fix off-by-one in signal handler bounds checks (`>` → `>=` for array indexed by `HIGHEST_SIGNAL`)
- Add input length validation in `find_hex` to prevent out-of-bounds reads on short hash strings
- Initialize `group` variable and check parse return value in `download_tracker_insert`
- Add `mask_bits==0` special case in CIDR parsing to avoid undefined behavior from shift by 32
- Catch all exceptions (not just `bencode_error`) for stack cleanup in `command_function_call_object`
- Add NULL check before `closedir` in `Directory::is_valid`
- Add empty file list check in `retrieve_d_base_filename` (matches existing guard in `retrieve_d_base_path`)

## Test plan
- [ ] Test `ip_tables.size_data` command with valid and invalid table names
- [ ] Test base64 decoding with strings containing `\r\n` line endings
- [ ] Test `log.vmmap.dump` with an invalid/unwritable path
- [ ] Test CIDR `/0` address range parsing
- [ ] Test `find_hex` with short/empty hash strings
- [ ] Build and verify no regressions in signal handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)