### PR TITLE
Fix display/UI crash and correctness bugs

### DIFF
--- a/src/command_peer.cc
+++ b/src/command_peer.cc
@@ -60,6 +60,8 @@ retrieve_p_options_str(torrent::Peer* peer) {
 
 torrent::Object
 retrieve_p_completed_percent(torrent::Peer* peer) {
+  if (peer->bitfield()->size_bits() == 0)
+    return int64_t(0);
   return (100 * peer->bitfield()->size_set()) / peer->bitfield()->size_bits();
 }
 

--- a/src/display/frame.cc
+++ b/src/display/frame.cc
@@ -361,7 +361,7 @@ Frame::balance_row(uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
     (*itr)->balance(x, y, m_width, std::min((*itr)->m_height, height));
 
     y += (*itr)->m_height;
-    height -= (*itr)->m_height;
+    height = ((*itr)->m_height <= height) ? height - (*itr)->m_height : 0;
   }
 }
 
@@ -436,7 +436,7 @@ Frame::balance_column(uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
     (*itr)->balance(x, y, std::min((*itr)->m_width, width), m_height);
 
     x += (*itr)->m_width;
-    width -= (*itr)->m_width;
+    width = ((*itr)->m_width <= width) ? width - (*itr)->m_width : 0;
   }
 }
 

--- a/src/display/text_element_string.cc
+++ b/src/display/text_element_string.cc
@@ -120,7 +120,7 @@ TextElementCommand::print(char* first, char* last, Canvas::attributes_list* attr
   }
   case torrent::Object::TYPE_VALUE:
   { 
-    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%lld", (long long int)result.as_value()), 0), last - first + 1);
+    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%lld", (long long int)result.as_value()), 0), last - first);
     break;
   }
   default:

--- a/src/display/text_element_value.cc
+++ b/src/display/text_element_value.cc
@@ -49,28 +49,28 @@ TextElementValueBase::print(char* first, char* last, Canvas::attributes_list* at
 
   } else if (m_flags & flag_kb) {
     // Just use a default width of 5 for now.
-    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%5.1f", (double)val / (1 << 10)), 0), last - first + 1);
+    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%5.1f", (double)val / (1 << 10)), 0), last - first);
 
   } else if (m_flags & flag_mb) {
     // Just use a default width of 8 for now.
-    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%8.1f", (double)val / (1 << 20)), 0), last - first + 1);
+    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%8.1f", (double)val / (1 << 20)), 0), last - first);
 
   } else if (m_flags & flag_xb) {
 
     if (val < (int64_t(1000) << 10))
-      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%5.1f KB", (double)val / (int64_t(1) << 10)), 0), last - first + 1);
+      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%5.1f KB", (double)val / (int64_t(1) << 10)), 0), last - first);
     else if (val < (int64_t(1000) << 20))
-      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%5.1f MB", (double)val / (int64_t(1) << 20)), 0), last - first + 1);
+      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%5.1f MB", (double)val / (int64_t(1) << 20)), 0), last - first);
     else if (val < (int64_t(1000) << 30))
-      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%5.1f GB", (double)val / (int64_t(1) << 30)), 0), last - first + 1);
+      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%5.1f GB", (double)val / (int64_t(1) << 30)), 0), last - first);
     else
-      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%5.1f TB", (double)val / (int64_t(1) << 40)), 0), last - first + 1);
+      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%5.1f TB", (double)val / (int64_t(1) << 40)), 0), last - first);
 
   } else if (m_flags & flag_timer) {
     if (val == 0)
-      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "--:--:--"), 0), last - first + 1);
+      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "--:--:--"), 0), last - first);
     else
-      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%2d:%02d:%02d", (int)(val / 3600), (int)((val / 60) % 60), (int)(val % 60)), 0), last - first + 1);
+      first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%2d:%02d:%02d", (int)(val / 3600), (int)((val / 60) % 60), (int)(val % 60)), 0), last - first);
 
   } else if (m_flags & flag_date) {
     time_t t = val;
@@ -79,7 +79,7 @@ TextElementValueBase::print(char* first, char* last, Canvas::attributes_list* at
     if (u == NULL)
       return first;
 
-    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%02u/%02u/%04u", u->tm_mday, (u->tm_mon + 1), (1900 + u->tm_year)), 0), last - first + 1);
+    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%02u/%02u/%04u", u->tm_mday, (u->tm_mon + 1), (1900 + u->tm_year)), 0), last - first);
 
   } else if (m_flags & flag_time) {
     time_t t = val;
@@ -88,10 +88,10 @@ TextElementValueBase::print(char* first, char* last, Canvas::attributes_list* at
     if (u == NULL)
       return first;
 
-    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%2d:%02d:%02d", u->tm_hour, u->tm_min, u->tm_sec), 0), last - first + 1);
+    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%2d:%02d:%02d", u->tm_hour, u->tm_min, u->tm_sec), 0), last - first);
 
   } else {
-    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first + 1, "%lld", (long long int)val), 0), last - first + 1);
+    first += std::min<ptrdiff_t>(std::max(snprintf(first, last - first, "%lld", (long long int)val), 0), last - first);
   }
 
   push_attribute(attributes, Attributes(first, baseAttribute));

--- a/src/display/utils.cc
+++ b/src/display/utils.cc
@@ -150,7 +150,7 @@ print_download_status(char* first, char* last, core::Download* d) {
 
   if (d->is_hash_checking()) {
     first = print_buffer(first, last, "Checking hash [%2i%%]",
-                         (d->download()->chunks_hashed() * 100) / d->download()->file_list()->size_chunks());
+                         d->download()->file_list()->size_chunks() != 0 ? (d->download()->chunks_hashed() * 100) / d->download()->file_list()->size_chunks() : 0);
 
   } else if (d->tracker_controller().has_active_trackers_not_scrape()) {
     auto tracker = d->tracker_controller().find_if([](const auto& t) {
@@ -208,7 +208,7 @@ print_download_info_compact(char* first, char* last, core::Download* d) {
   if (d->is_done())
     first = print_buffer(first, last, " 100%% ");
   else if (d->is_open())
-    first = print_buffer(first, last, "  %2u%% ",(d->download()->file_list()->completed_chunks() * 100) / d->download()->file_list()->size_chunks());
+    first = print_buffer(first, last, "  %2u%% ", d->download()->file_list()->size_chunks() != 0 ? (d->download()->file_list()->completed_chunks() * 100) / d->download()->file_list()->size_chunks() : 0);
   else
     first = print_buffer(first, last, "      ");
 
@@ -260,7 +260,7 @@ print_download_percentage_done(char* first, char* last, core::Download* d) {
     //return print_buffer(first, last, "[--%%]");
     return print_buffer(first, last, "     ");
   else
-    return print_buffer(first, last, "[%2u%%]", (d->download()->file_list()->completed_chunks() * 100) / d->download()->file_list()->size_chunks());
+    return print_buffer(first, last, "[%2u%%]", d->download()->file_list()->size_chunks() != 0 ? (d->download()->file_list()->completed_chunks() * 100) / d->download()->file_list()->size_chunks() : 0);
 }
 
 char*

--- a/src/display/window_http_queue.cc
+++ b/src/display/window_http_queue.cc
@@ -19,7 +19,7 @@ WindowHttpQueue::WindowHttpQueue(core::HttpQueue* q) :
   set_active(false);
 
   m_conn_insert = m_queue->signal_insert().insert(m_queue->signal_insert().end(), [this](auto h) { receive_insert(h); });
-  m_conn_erase  = m_queue->signal_erase().insert(m_queue->signal_insert().end(), [this](auto h) { receive_erase(h); });
+  m_conn_erase  = m_queue->signal_erase().insert(m_queue->signal_erase().end(), [this](auto h) { receive_erase(h); });
 
   m_task_deactivate.slot() = [this] {
       if (!m_container.empty())

--- a/src/display/window_input.cc
+++ b/src/display/window_input.cc
@@ -12,7 +12,7 @@ WindowInput::redraw() {
   m_canvas->erase();
   m_canvas->print(0, 0, "%s> %s", m_title.c_str(), m_input != NULL ? m_input->c_str() : "<NULL>");
 
-  if (m_focus)
+  if (m_focus && m_input != NULL)
     m_canvas->set_attr(m_input->get_pos() + 2 + m_title.size(), 0, 1, A_REVERSE, COLOR_PAIR(0));
 }
 

--- a/src/ui/element_download_list.cc
+++ b/src/ui/element_download_list.cc
@@ -167,6 +167,8 @@ ElementDownloadList::receive_home() {
 
 void
 ElementDownloadList::receive_end() {
+  if (m_view->size_visible() == 0)
+    return;
   m_view->set_focus(m_view->end_visible() - 1);
   m_view->set_last_changed();
 }
@@ -221,10 +223,10 @@ ElementDownloadList::receive_change_view(const std::string& name) {
 
   std::string old_name = view() ? view()->name() : "";
   if (!old_name.empty())
-    rpc::commands.call_catch("event.view.hide", rpc::make_target(), name, "View hide event action failed: ");
+    rpc::commands.call_catch("event.view.hide", rpc::make_target(), old_name, "View hide event action failed: ");
   set_view(*itr);
-  if (!old_name.empty())
-    rpc::commands.call_catch("event.view.show", rpc::make_target(), old_name, "View show event action failed: ");
+  if (!name.empty())
+    rpc::commands.call_catch("event.view.show", rpc::make_target(), name, "View show event action failed: ");
 }
 
 void

--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -496,7 +496,7 @@ Root::set_keymap_style(const std::string& style) {
   } else if (style == "emacs") {
     m_keymap = emacs_keymap;
   } else {
-    throw torrent::input_error("Root::set_keymap_style() -> ui.keymap.style is configured with unknown keymap style: " + m_keymap_style);
+    throw torrent::input_error("Root::set_keymap_style() -> ui.keymap.style is configured with unknown keymap style: " + style);
   }
 
   m_keymap_style = style;


### PR DESCRIPTION
## Summary
- Fix wrong signal list iterator in `WindowHttpQueue` constructor (`signal_insert().end()` → `signal_erase().end()`)
- Fix swapped view show/hide event arguments in `receive_change_view` (hide event was passing new view name, show event was passing old view name)
- Add division-by-zero guards for `size_chunks()==0` in three display utility functions
- Add `m_input` null check in `WindowInput::redraw` when `m_focus` is set
- Add empty view guard for `end_visible()-1` in `receive_end` to prevent iterator underflow
- Fix snprintf buffer size off-by-one (`last - first + 1` → `last - first`) in text element rendering
- Add division-by-zero guard in `retrieve_p_completed_percent` when peer has no bitfield
- Fix error message in `set_keymap_style` showing old style instead of the rejected new style
- Saturate unsigned subtraction at 0 in `balance_row`/`balance_column` to prevent uint32_t underflow

## Test plan
- [ ] Test HTTP queue display with concurrent downloads
- [ ] Test view switching and verify correct show/hide events fire
- [ ] Test display with downloads that have 0 chunks (e.g. magnet links before metadata)
- [ ] Test input window focus with no active text input
- [ ] Test pressing End key on an empty view
- [ ] Test peer list display with peers that have empty bitfields
- [ ] Test `ui.keymap.style` with invalid style name — error should show the invalid style

🤖 Generated with [Claude Code](https://claude.com/claude-code)