### PR TITLE
Whitelist additional read-only getters for untrusted connections

### DIFF
--- a/src/command_download.cc
+++ b/src/command_download.cc
@@ -934,6 +934,10 @@ initialize_command_download() {
   rpc::rpc.mark_safe("d.size_chunks");
   rpc::rpc.mark_safe("d.size_pex");
   rpc::rpc.mark_safe("d.completed_bytes");
+  rpc::rpc.mark_safe("d.bytes_done");
+  rpc::rpc.mark_safe("d.peers_accounted");
+  rpc::rpc.mark_safe("d.chunks_hashed");
+  rpc::rpc.mark_safe("d.tracker_size");
   rpc::rpc.mark_safe("d.completed_chunks");
   rpc::rpc.mark_safe("d.left_bytes");
   rpc::rpc.mark_safe("d.chunk_size");

--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -336,4 +336,21 @@ initialize_command_local() {
   rpc::rpc.mark_safe("system.api_version");
   rpc::rpc.mark_safe("system.client_version");
   rpc::rpc.mark_safe("system.library_version");
+  rpc::rpc.mark_safe("system.file.max_size");
+  rpc::rpc.mark_safe("system.file.split_size");
+  rpc::rpc.mark_safe("system.file.split_suffix");
+
+  rpc::rpc.mark_safe("directory.default");
+  rpc::rpc.mark_safe("session.path");
+  rpc::rpc.mark_safe("session.use_lock");
+  rpc::rpc.mark_safe("session.on_completion");
+
+  rpc::rpc.mark_safe("pieces.sync.always_safe");
+  rpc::rpc.mark_safe("pieces.sync.timeout");
+  rpc::rpc.mark_safe("pieces.sync.timeout_safe");
+  rpc::rpc.mark_safe("pieces.preload.type");
+  rpc::rpc.mark_safe("pieces.preload.min_size");
+  rpc::rpc.mark_safe("pieces.preload.min_rate");
+  rpc::rpc.mark_safe("pieces.memory.max");
+  rpc::rpc.mark_safe("pieces.hash.on_completion");
 }

--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -342,6 +342,13 @@ initialize_command_network() {
   rpc::rpc.mark_safe("network.bind_address");
   rpc::rpc.mark_safe("network.local_address");
   rpc::rpc.mark_safe("network.xmlrpc.size_limit");
+  rpc::rpc.mark_safe("network.open_sockets");
+  rpc::rpc.mark_safe("network.http.cacert");
+  rpc::rpc.mark_safe("network.http.capath");
+  rpc::rpc.mark_safe("network.http.proxy_address");
+  rpc::rpc.mark_safe("network.proxy_address");
+  rpc::rpc.mark_safe("network.scgi.dont_route");
+  rpc::rpc.mark_safe("protocol.pex");
 
   rpc::rpc.mark_safe("network.rpc.use_xmlrpc");
   rpc::rpc.mark_safe("network.rpc.use_jsonrpc");

--- a/src/command_tracker.cc
+++ b/src/command_tracker.cc
@@ -180,4 +180,6 @@ initialize_command_tracker() {
   rpc::rpc.mark_safe("dht.override_port");
   rpc::rpc.mark_safe("dht.add_node");
   rpc::rpc.mark_safe("dht.statistics");
+  rpc::rpc.mark_safe("trackers.numwant");
+  rpc::rpc.mark_safe("trackers.use_udp");
 }


### PR DESCRIPTION
This PR mark_safe's a few more methods that ruTorrent needs use from browser.  Since we're using a whitelist (the original implementation was a blacklist), we're using deployed instances to get an accurate list of required methods.

The ones included here are only getters without side effects and the current ruTorrent uses them.

