### PR TITLE
fix off-by-one in SCgiTask::event_read

### DIFF
--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -80,7 +80,12 @@ SCgiTask::close() {
 
 void
 SCgiTask::event_read() {
-  int bytes = ::recv(m_fileDesc, m_buffer.data() + m_position, m_buffer.size() - m_position - (m_content_length == 0), 0);
+  int read_length = m_buffer.size() - m_position;
+  
+  if (m_content_length == 0)
+    read_length--;
+  
+  int bytes = ::recv(m_fileDesc, m_buffer.data() + m_position, read_length, 0);
 
   if (bytes <= 0) {
     if (bytes == 0 || !(errno == EAGAIN || errno == EINTR))

--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -84,6 +84,9 @@ SCgiTask::event_read() {
   
   if (m_content_length == 0)
     read_length--;
+
+  if (read_length <= 0)
+    throw torrent::internal_error("SCgiTask::event_read() no space in buffer for event_read.");
   
   int bytes = ::recv(m_fileDesc, m_buffer.data() + m_position, read_length, 0);
 

--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -80,7 +80,7 @@ SCgiTask::close() {
 
 void
 SCgiTask::event_read() {
-  int bytes = ::recv(m_fileDesc, m_buffer.data() + m_position, m_buffer.size() - m_position, 0);
+  int bytes = ::recv(m_fileDesc, m_buffer.data() + m_position, m_buffer.size() - m_position - (m_content_length == 0), 0);
 
   if (bytes <= 0) {
     if (bytes == 0 || !(errno == EAGAIN || errno == EINTR))


### PR DESCRIPTION
Reads one byte less if m_content_length is 0. Fixes #1748.