### PR TITLE
Move d.save_full_session to run after user-registered inserted_new handlers

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -209,7 +209,14 @@ main(int argc, char** argv) {
        "method.insert = event.download.hash_queued,multi|rlookup|static\n"
 
        "method.set_key = event.download.inserted,         1_send_scrape, ((d.tracker.send_scrape,30))\n"
-       "method.set_key = event.download.inserted_new,     1_prepare, {(branch,((d.state)),((view.set_visible,started)),((view.set_visible,stopped)) ),(d.save_full_session)}\n"
+       "method.set_key = event.download.inserted_new,     1_prepare,   {(branch,((d.state)),((view.set_visible,started)),((view.set_visible,stopped)) )}\n"
+       // d.save_full_session runs LAST (~ prefix is ASCII 0x7E, sorts after all alphanumerics,
+       // matching the existing ~_delete_tied precedent on event.download.erased) so the on-disk
+       // snapshot includes custom fields written by other inserted_new handlers (addtime,
+       // seedingtime, etc.). Was previously inside 1_prepare alongside view setup, which
+       // snapshotted bencode before later handlers ran, so d.set_custom=addtime did not reach
+       // .rtorrent until the next periodic resume save — a window where rtorrent restart lost them.
+       "method.set_key = event.download.inserted_new,     ~_save_full, ((d.save_full_session))\n"
        "method.set_key = event.download.inserted_session, 1_prepare, {(branch,((d.state)),((view.set_visible,started)),((view.set_visible,stopped)) )}\n"
 
        "method.set_key = event.download.inserted, 1_prioritize_toc, \"branch=file.prioritize_toc=,{\\\"f.multicall=(file.prioritize_toc.first),f.prioritize_first.enable=\\\",\\\"f.multicall=(file.prioritize_toc.last),f.prioritize_last.enable=\\\",d.update_priorities=}\"\n"


### PR DESCRIPTION
Since 0.16.6 moved session saving to a separate thread, `save_full_download()` synchronously snapshots the bencode when called and queues prebuilt streamsfor async write.

If user-registered handlers (e.g. `d.set_custom=addtime,$execute_capture=...`) sort lexicographically AFTER `1_prepare`, they modify the bencode AFTER the snapshot has been taken. The first on-disk `.rtorrent` then lacks those custom fields. The next periodic resume save catches up — but if rtorrent restarts before that, the data is lost.

This manifests in ruTorrent as blank Finished/SeedingTime/AddTime columns for some torrents (Novik/ruTorrent#3050).

## Test

Verified on a downstream patched 0.16.11 build with ruTorrent: addtime present in `.rtorrent` immediately after add, mtime matches add time.