### PR TITLE
Log tracker failures as warnings

### DIFF
--- a/src/core/download.cc
+++ b/src/core/download.cc
@@ -10,6 +10,7 @@
 #include <torrent/data/file.h>
 #include <torrent/data/file_list.h>
 #include <torrent/utils/file_stat.h>
+#include <torrent/utils/log.h>
 
 #include "rpc/parse_commands.h"
 
@@ -72,10 +73,12 @@ Download::connection_list_size() const {
 
 void
 Download::receive_tracker_msg(std::string msg) {
-  if (msg.empty())
+  if (msg.empty()) {
     m_message = "";
-  else
+  } else {
     m_message = "Tracker: [" + msg + "]";
+    lt_log_print_info(torrent::LOG_WARN, m_download.info(), "tracker", "%s", m_message.c_str());
+  }
 }
 
 float


### PR DESCRIPTION
## Summary

Fixes #1048 by logging tracker failure messages at warning level in addition to the existing UI status message.

This makes tracker failures visible through less-verbose log outputs such as `warn`, without changing the existing tracker event/request logging behavior.

## Verification

- `git diff --check`
- Built official `libtorrent-0.16.11` release tarball into a local prefix
- Configured official `rtorrent-0.16.11` release tarball against that local prefix
- `make core/download.o`

Note: a full `make -j2` on the release tarball stopped in unrelated `command_ui.cc` template code before reaching this changed file.
