### PR TITLE
Honor trackers.use_udp for loaded torrents

### DIFF
--- a/src/command_tracker.cc
+++ b/src/command_tracker.cc
@@ -86,6 +86,18 @@ apply_enable_trackers(int64_t arg) {
   return torrent::Object();
 }
 
+torrent::Object
+apply_use_udp_trackers(int64_t arg) {
+  const bool use_udp = arg != 0;
+
+  control->object_storage()->set_bool(torrent::raw_string::from_c_str("trackers.use_udp"), use_udp);
+
+  for (auto download : *control->core()->download_list())
+    download->enable_udp_trackers(use_udp);
+
+  return torrent::Object(static_cast<int64_t>(use_udp));
+}
+
 void
 initialize_command_tracker() {
   CMD2_TRACKER        ("t.is_busy",           std::bind(&torrent::tracker::Tracker::is_busy, std::placeholders::_1));
@@ -137,7 +149,10 @@ initialize_command_tracker() {
   CMD2_ANY_VALUE      ("trackers.disable",    std::bind(&apply_enable_trackers, int64_t(0)));
   CMD2_VAR_BOOL       ("trackers.delay_scrape", false);
   CMD2_VAR_VALUE      ("trackers.numwant",    -1);
-  CMD2_VAR_BOOL       ("trackers.use_udp",    true);
+  control->object_storage()->insert_c_str("trackers.use_udp", int64_t(1), rpc::object_storage::flag_bool_type);
+  CMD2_ANY            ("trackers.use_udp",    std::bind(&rpc::object_storage::get, control->object_storage(),
+                                                        torrent::raw_string::from_c_str("trackers.use_udp")));
+  CMD2_ANY_VALUE      ("trackers.use_udp.set", std::bind(&apply_use_udp_trackers, std::placeholders::_2));
 
   auto dht_manager = control->dht_manager();
 

--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -238,9 +238,6 @@ DownloadFactory::receive_success() {
       rpc::call_command("d.peers_max.set", rpc::call_command("throttle.max_peers.seed"), rpc::make_target(download));
   }
 
-  if (!rpc::call_command_value("trackers.use_udp"))
-    download->enable_udp_trackers(false);
-
   // Skip forcing trackers to scrape when rtorrent starts
   if (m_initLoad && rpc::call_command_value("trackers.delay_scrape"))
     download->set_resume_flags(torrent::Download::start_skip_tracker);
@@ -277,6 +274,9 @@ DownloadFactory::receive_success() {
   torrent::resume_load_addresses(*download->download(), resumeObject);
   torrent::resume_load_file_priorities(*download->download(), resumeObject);
   torrent::resume_load_tracker_settings(*download->download(), resumeObject);
+
+  if (!rpc::call_command_value("trackers.use_udp"))
+    download->enable_udp_trackers(false);
 
   // The action of inserting might cause the torrent to be
   // opened/started or such. Figure out a nicer way of handling this.


### PR DESCRIPTION
This fixes rakshasa/rtorrent#1043.

`trackers.use_udp.set = no` already updates the global setting, but loaded session torrents could still have UDP trackers enabled again after resume tracker settings were restored. This moves the UDP tracker disabling after resume tracker settings are loaded, and makes the runtime setter apply the setting to already-loaded downloads as well.

Local validation:
- `git diff --check` passes.

I could not run the full autotools build locally from this Windows environment, so I will rely on GitHub Actions for build/test validation.