### PR TITLE
Honor trackers.use_udp for loaded torrents

### DIFF
--- a/src/command_tracker.cc
+++ b/src/command_tracker.cc
@@ -63,6 +63,18 @@ apply_dht_add_node(const std::string& arg) {
 }
 
 torrent::Object
+apply_trackers_use_udp(int64_t arg) {
+  const auto& use_udp = control->object_storage()->set_c_str_bool("trackers.use_udp", arg);
+
+  if (use_udp.as_value() == 0) {
+    for (auto download : *control->core()->download_list())
+      download->enable_udp_trackers(false);
+  }
+
+  return use_udp;
+}
+
+torrent::Object
 apply_enable_trackers(int64_t arg) {
   if (arg == 0) {
     for (auto download : *control->core()->download_list())
@@ -84,6 +96,14 @@ apply_enable_trackers(int64_t arg) {
   }
 
   return torrent::Object();
+}
+
+void
+initialize_command_tracker_use_udp() {
+  control->object_storage()->insert_c_str("trackers.use_udp", int64_t(true), rpc::object_storage::flag_bool_type);
+  CMD2_ANY            ("trackers.use_udp",    std::bind(&rpc::object_storage::get, control->object_storage(),
+                                                        torrent::raw_string::from_c_str("trackers.use_udp")));
+  CMD2_ANY_VALUE      ("trackers.use_udp.set", std::bind(&apply_trackers_use_udp, std::placeholders::_2));
 }
 
 void
@@ -137,7 +157,7 @@ initialize_command_tracker() {
   CMD2_ANY_VALUE      ("trackers.disable",    std::bind(&apply_enable_trackers, int64_t(0)));
   CMD2_VAR_BOOL       ("trackers.delay_scrape", false);
   CMD2_VAR_VALUE      ("trackers.numwant",    -1);
-  CMD2_VAR_BOOL       ("trackers.use_udp",    true);
+  initialize_command_tracker_use_udp();
 
   auto dht_manager = control->dht_manager();
 

--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -238,9 +238,6 @@ DownloadFactory::receive_success() {
       rpc::call_command("d.peers_max.set", rpc::call_command("throttle.max_peers.seed"), rpc::make_target(download));
   }
 
-  if (!rpc::call_command_value("trackers.use_udp"))
-    download->enable_udp_trackers(false);
-
   // Skip forcing trackers to scrape when rtorrent starts
   if (m_initLoad && rpc::call_command_value("trackers.delay_scrape"))
     download->set_resume_flags(torrent::Download::start_skip_tracker);
@@ -277,6 +274,9 @@ DownloadFactory::receive_success() {
   torrent::resume_load_addresses(*download->download(), resumeObject);
   torrent::resume_load_file_priorities(*download->download(), resumeObject);
   torrent::resume_load_tracker_settings(*download->download(), resumeObject);
+
+  if (!rpc::call_command_value("trackers.use_udp"))
+    download->enable_udp_trackers(false);
 
   // The action of inserting might cause the torrent to be
   // opened/started or such. Figure out a nicer way of handling this.

--- a/test/src/test_command_dynamic.cc
+++ b/test/src/test_command_dynamic.cc
@@ -9,6 +9,7 @@
 CPPUNIT_TEST_SUITE_REGISTRATION(TestCommandDynamic);
 
 void initialize_command_dynamic();
+void initialize_command_tracker_use_udp();
 void initialize_command_ui();
 
 void
@@ -60,4 +61,17 @@ TestCommandDynamic::test_old_style() {
 
   rpc::commands.call_command("method.insert", rpc::create_object_list("test_old_style.4", "simple", "cat=test.3"));
   CPPUNIT_ASSERT(rpc::commands.call_command("test_old_style.4", torrent::Object()).as_string() == "test.3");
+}
+
+void
+TestCommandDynamic::test_trackers_use_udp() {
+  initialize_command_tracker_use_udp();
+
+  CPPUNIT_ASSERT(rpc::commands.call_command("trackers.use_udp", torrent::Object()).as_value() == 1);
+
+  rpc::parse_command_single(rpc::make_target(), "trackers.use_udp.set = no");
+  CPPUNIT_ASSERT(rpc::commands.call_command("trackers.use_udp", torrent::Object()).as_value() == 0);
+
+  rpc::parse_command_single(rpc::make_target(), "trackers.use_udp.set = yes");
+  CPPUNIT_ASSERT(rpc::commands.call_command("trackers.use_udp", torrent::Object()).as_value() == 1);
 }

--- a/test/src/test_command_dynamic.h
+++ b/test/src/test_command_dynamic.h
@@ -7,6 +7,7 @@ class TestCommandDynamic : public test_fixture {
   CPPUNIT_TEST(test_basics);
   CPPUNIT_TEST(test_get_set);
   CPPUNIT_TEST(test_old_style);
+  CPPUNIT_TEST(test_trackers_use_udp);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -18,6 +19,7 @@ public:
   void test_get_set();
 
   void test_old_style();
+  void test_trackers_use_udp();
 
 private:
   std::unique_ptr<TestMainThread> m_test_main_thread;


### PR DESCRIPTION
Fixes #1043.

`trackers.use_udp.set = no` already changed the global setting, but loaded torrents could keep UDP trackers enabled. This makes the setter immediately disable UDP trackers on currently loaded downloads, and applies the startup/session-load check after resume tracker settings are restored so saved tracker state cannot re-enable them.

I kept `trackers.use_udp.set = yes` as a setting change only, so it does not unexpectedly re-enable trackers a user may have disabled manually.

Validation:
- `make -j2`
- `make -C test rtorrent_Test_Src`
- `./test/rtorrent_Test_Src`
- `make check`
- `git diff --check`