### PR TITLE
Deprecate trackers.use_udp as it is no longer needed.

### DIFF
--- a/src/command_tracker.cc
+++ b/src/command_tracker.cc
@@ -68,16 +68,6 @@ apply_enable_trackers(int64_t arg) {
     for (auto download : *control->core()->download_list())
       download->tracker_controller().for_each([](auto& tracker) { tracker.disable(); });
 
-  } else if (rpc::call_command_value("trackers.use_udp") == 0) {
-    for (auto download : *control->core()->download_list()) {
-      download->tracker_controller().for_each([](auto& tracker) {
-        if (tracker.type() == torrent::TRACKER_UDP)
-          tracker.disable();
-        else
-          tracker.enable();
-      });
-    }
-
   } else {
     for (auto download : *control->core()->download_list())
       download->tracker_controller().for_each([](auto& tracker) { tracker.enable(); });
@@ -108,36 +98,40 @@ initialize_command_tracker() {
   CMD2_TRACKER        ("t.type",              std::bind(&torrent::tracker::Tracker::type, std::placeholders::_1));
   CMD2_TRACKER        ("t.id",                std::bind(&torrent::tracker::Tracker::tracker_id, std::placeholders::_1));
 
-  CMD2_TRACKER        ("t.latest_event",      [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().latest_event(); });
-  CMD2_TRACKER        ("t.latest_new_peers",  [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().latest_new_peers(); });
-  CMD2_TRACKER        ("t.latest_sum_peers",  [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().latest_sum_peers(); });
+  CMD2_TRACKER        ("t.latest_event",      [](auto* tracker, auto) { return tracker->state().latest_event(); });
+  CMD2_TRACKER        ("t.latest_new_peers",  [](auto* tracker, auto) { return tracker->state().latest_new_peers(); });
+  CMD2_TRACKER        ("t.latest_sum_peers",  [](auto* tracker, auto) { return tracker->state().latest_sum_peers(); });
 
-  CMD2_TRACKER        ("t.normal_interval",   [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().normal_interval(); });
-  CMD2_TRACKER        ("t.min_interval",      [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().min_interval(); });
+  CMD2_TRACKER        ("t.normal_interval",   [](auto* tracker, auto) { return tracker->state().normal_interval(); });
+  CMD2_TRACKER        ("t.min_interval",      [](auto* tracker, auto) { return tracker->state().min_interval(); });
 
-  CMD2_TRACKER        ("t.activity_time_next", [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().activity_time_next(); });
-  CMD2_TRACKER        ("t.activity_time_last", [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().activity_time_last(); });
+  CMD2_TRACKER        ("t.activity_time_next", [](auto* tracker, auto) { return tracker->state().activity_time_next(); });
+  CMD2_TRACKER        ("t.activity_time_last", [](auto* tracker, auto) { return tracker->state().activity_time_last(); });
 
-  CMD2_TRACKER        ("t.success_time_next", [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().success_time_next(); });
-  CMD2_TRACKER        ("t.success_time_last", [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().success_time_last(); });
-  CMD2_TRACKER        ("t.success_counter",   [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().success_counter(); });
+  CMD2_TRACKER        ("t.success_time_next", [](auto* tracker, auto) { return tracker->state().success_time_next(); });
+  CMD2_TRACKER        ("t.success_time_last", [](auto* tracker, auto) { return tracker->state().success_time_last(); });
+  CMD2_TRACKER        ("t.success_counter",   [](auto* tracker, auto) { return tracker->state().success_counter(); });
 
-  CMD2_TRACKER        ("t.failed_time_next",  [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().failed_time_next(); });
-  CMD2_TRACKER        ("t.failed_time_last",  [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().failed_time_last(); });
-  CMD2_TRACKER        ("t.failed_counter",    [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().failed_counter(); });
+  CMD2_TRACKER        ("t.failed_time_next",  [](auto* tracker, auto) { return tracker->state().failed_time_next(); });
+  CMD2_TRACKER        ("t.failed_time_last",  [](auto* tracker, auto) { return tracker->state().failed_time_last(); });
+  CMD2_TRACKER        ("t.failed_counter",    [](auto* tracker, auto) { return tracker->state().failed_counter(); });
 
-  CMD2_TRACKER        ("t.scrape_time_last",  [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().scrape_time_last(); });
-  CMD2_TRACKER        ("t.scrape_counter",    [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().scrape_counter(); });
+  CMD2_TRACKER        ("t.scrape_time_last",  [](auto* tracker, auto) { return tracker->state().scrape_time_last(); });
+  CMD2_TRACKER        ("t.scrape_counter",    [](auto* tracker, auto) { return tracker->state().scrape_counter(); });
 
-  CMD2_TRACKER        ("t.scrape_complete",   [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().scrape_complete(); });
-  CMD2_TRACKER        ("t.scrape_incomplete", [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().scrape_incomplete(); });
-  CMD2_TRACKER        ("t.scrape_downloaded", [](torrent::tracker::Tracker* tracker, [[maybe_unused]] auto o) -> auto { return tracker->state().scrape_downloaded(); });
+  CMD2_TRACKER        ("t.scrape_complete",   [](auto* tracker, auto) { return tracker->state().scrape_complete(); });
+  CMD2_TRACKER        ("t.scrape_incomplete", [](auto* tracker, auto) { return tracker->state().scrape_incomplete(); });
+  CMD2_TRACKER        ("t.scrape_downloaded", [](auto* tracker, auto) { return tracker->state().scrape_downloaded(); });
 
   CMD2_ANY_VALUE      ("trackers.enable",     std::bind(&apply_enable_trackers, int64_t(1)));
   CMD2_ANY_VALUE      ("trackers.disable",    std::bind(&apply_enable_trackers, int64_t(0)));
   CMD2_VAR_BOOL       ("trackers.delay_scrape", false);
   CMD2_VAR_VALUE      ("trackers.numwant",    -1);
-  CMD2_VAR_BOOL       ("trackers.use_udp",    true);
+
+  CMD2_ANY            ("trackers.use_udp",     [](auto, auto) { return false; });
+  CMD2_ANY_VALUE_V    ("trackers.use_udp.set", [](auto, auto) {
+      lt_log_print(torrent::LOG_ERROR, "trackers.use_udp.set is no longer supported", 0);
+    })
 
   auto dht_manager = control->dht_manager();
 


### PR DESCRIPTION
All the issues that required disabling udp trackers have now been fixed.