### PR TITLE
fix: set d.message on hash check failure

### DIFF
--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -492,7 +492,11 @@ DownloadList::hash_done(Download* download) {
 
   if (!download->is_hash_checked()) {
     download->set_hash_failed(true);
-    
+
+    auto& msg = download->download()->hash_error_message();
+    if (!msg.empty())
+      download->set_message(msg);
+
     DL_TRIGGER_EVENT(download, "event.download.hash_failed");
     return;
   }

--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -513,6 +513,7 @@ Manager::receive_hashing_changed() {
 
       } else {
         (*itr)->set_hash_failed(true);
+        (*itr)->set_message("Hashing failed: " + std::string(e.what()));
         lt_log_print(torrent::LOG_TORRENT_ERROR, "Hashing failed: %s", e.what());
       }
     }


### PR DESCRIPTION
## Summary

- Populate `d.message` with the specific error message when a hash check fails, instead of leaving it empty.

## Motivation

When rtorrent finishes downloading and the final hash check encounters an I/O error, `d.hashing_failed` is set to `true` but `d.message` is left empty. This makes it impossible to debug the root cause of the failure.

## Changes

In `DownloadList::hash_done()`, after setting `hash_failed(true)`, retrieve the error message from the hash checker via the new `Download::hash_error_message()` API and set it as `d.message`.

Also fix `Manager::receive_hashing_changed()` where `set_hash_failed(true)` was called without setting `d.message` when catching `local_error` during hash check (e.g. "too many open files").

## Dependency

Requires [libtorrent#747](https://github.com/rakshasa/libtorrent/pull/747) which adds `Download::hash_error_message()`.