### PR TITLE
rpc: fix --with-xmlrpc-c backend build (flag name + base64 args)

### DIFF
--- a/src/rpc/xmlrpc_c.cc
+++ b/src/rpc/xmlrpc_c.cc
@@ -278,7 +278,7 @@ object_to_xmlrpc(xmlrpc_env* env, const torrent::Object& object) {
 
   case torrent::Object::TYPE_STRING:
   {
-    if (object.flags() & torrent::Object::flag_binary) {
+    if (object.flags() & torrent::Object::flag_as_binary) {
 
       // This causes decode-and-reencode for base64, as XMLRPC-C doesn't allow us to pass base64 strings.
       if (object.flags() & torrent::Object::flag_base64) {
@@ -287,10 +287,10 @@ object_to_xmlrpc(xmlrpc_env* env, const torrent::Object& object) {
         if (!binary_data.has_value())
           throw torrent::input_error("invalid base64 string in base64-as-binary object");
 
-        return xmlrpc_base64_new(env, (const char*)binary_data->data(), binary_data->size());
+        return xmlrpc_base64_new(env, binary_data->size(), binary_data->data());
       }
 
-      return xmlrpc_base64_new(env, object.as_string().c_str(), object.as_string().size());
+      return xmlrpc_base64_new(env, object.as_string().size(), (const unsigned char*)object.as_string().c_str());
     }
 
 #ifdef XMLRPC_HAVE_I8


### PR DESCRIPTION
The XMLRPC-C backend (src/rpc/xmlrpc_c.cc) has not compiled since the base64-for-non-UTF8 work landed. object_to_xmlrpc() has three errors, none caught by CI: the unit-tests workflow runs a bare ./configure with neither --with-xmlrpc-c nor --with-xmlrpc-tinyxml2 and installs no xmlrpc-c headers, so this translation unit is never built upstream.

1. torrent::Object::flag_binary does not exist; the libtorrent flag is flag_as_binary (0x800000, "Treat as binary data"). Use it.

2-3. xmlrpc_base64_new() takes (xmlrpc_env*, size_t length,
   const unsigned char* value), but both calls pass (value, length), which
   fails to compile: invalid conversion from size_type to const unsigned char*.
   Swap the arguments to match the library.

Builds cleanly with --with-xmlrpc-c against current libtorrent master.