### PR TITLE
Unregister destroyed ElementLogComplete and WindowLog

### DIFF
--- a/src/display/window_log.cc
+++ b/src/display/window_log.cc
@@ -26,6 +26,7 @@ WindowLog::WindowLog(torrent::log_buffer* l) :
 }
 
 WindowLog::~WindowLog() {
+  m_log->lock_and_set_update_slot(nullptr);
   torrent::this_thread::scheduler()->erase(&m_task_update);
 }
 

--- a/src/ui/element_log_complete.cc
+++ b/src/ui/element_log_complete.cc
@@ -26,6 +26,10 @@ ElementLogComplete::ElementLogComplete(torrent::log_buffer* l) :
     });
 }
 
+ElementLogComplete::~ElementLogComplete() {
+  m_log->lock_and_set_update_slot(nullptr);
+}
+
 void
 ElementLogComplete::activate(display::Frame* frame, [[maybe_unused]] bool focus) {
   if (is_active())

--- a/src/ui/element_log_complete.h
+++ b/src/ui/element_log_complete.h
@@ -18,6 +18,7 @@ public:
   typedef display::WindowLogComplete    WLogComplete;
 
   ElementLogComplete(torrent::log_buffer* l);
+  virtual ~ElementLogComplete();
 
   void                activate(display::Frame* frame, bool focus = true);
   void                disable();

--- a/src/ui/element_log_complete.h
+++ b/src/ui/element_log_complete.h
@@ -18,7 +18,7 @@ public:
   typedef display::WindowLogComplete    WLogComplete;
 
   ElementLogComplete(torrent::log_buffer* l);
-  virtual ~ElementLogComplete();
+  ~ElementLogComplete() override;
 
   void                activate(display::Frame* frame, bool focus = true);
   void                disable();


### PR DESCRIPTION
Fixes ElementLogComplete use-after-free when `Control::cleanup()` cleans up the UI first, and core then attempts to log in `DhtController::stop()`.