### PR TITLE
fix(rpc): preserve c_str() stability of stored XMLRPC method names

### DIFF
--- a/src/rpc/xmlrpc.cc
+++ b/src/rpc/xmlrpc.cc
@@ -1,3 +1,4 @@
+#include <deque>
 #include "config.h"
 
 #include "xmlrpc.h"
@@ -9,7 +10,7 @@
 
 namespace rpc {
 
-std::vector<std::string> XmlRpc::m_command_names;
+std::deque<std::string>  XmlRpc::m_command_names;
 
 const char*
 XmlRpc::store_command_name(const char* name) {

--- a/src/rpc/xmlrpc.h
+++ b/src/rpc/xmlrpc.h
@@ -1,6 +1,7 @@
 #ifndef RTORRENT_RPC_XMLRPC_H
 #define RTORRENT_RPC_XMLRPC_H
 
+#include <deque>
 #include <functional>
 #include <torrent/common.h>
 #include <torrent/hash_string.h>
@@ -61,7 +62,7 @@ public:
 private:
   static const char*  store_command_name(const char* name);
 
-  static std::vector<std::string> m_command_names;
+  static std::deque<std::string>  m_command_names;
 
   slot_download       m_slotFindDownload;
   slot_file           m_slotFindFile;


### PR DESCRIPTION
Commit 6488131 ("Fix RPC/SCGI security and crash bugs by @sirus20x6") replaced std::vector<std::unique_ptr<const char>> storage with std::vector<std::string> and returned back().c_str() to the xmlrpc-c registry as the per-method server_info pointer.

This is unsafe for any method name short enough to be SSO-stored (<= 15 chars on libstdc++): such a string keeps its buffer inside the std::string object itself. When a later push_back reallocates the vector and move-constructs the existing elements into a new buffer, the previously returned c_str() pointers — captured by xmlrpc-c at registration time — dangle into freed memory.

Because xmlrpc-c does not dereference server_info until a call dispatches, the failure surfaces later as nondeterministic garbage in fault strings, e.g.

  faultString: Command "thod." does not exist.    (load.start, log.xmlrpc, log.execute)
  faultString: Command "in_rate" does not exist.  (log.add_output)
  faultString: Command ""       does not exist.   (log.open_file)
  faultString: Command "+U"     does not exist.   (method.set_key)

Long-named methods (e.g. system.client_version at 21 chars) are heap-allocated above the SSO threshold and escape the bug because the heap buffer's address is preserved across the vector move.

Switch the storage to std::deque<std::string>: per [deque.modifiers] push_back does not invalidate references to existing elements, so the std::string objects do not move and the c_str() pointers handed to xmlrpc-c remain valid for the program's lifetime. The body of store_command_name is unchanged.

Fixes the use-after-free; preserves the std::string-based storage the original commit aimed for.