### PR TITLE
fix: define default_resume_flags sentinel, clearing open_enable_fallocate

### DIFF
--- a/src/core/download.h
+++ b/src/core/download.h
@@ -22,6 +22,8 @@ public:
   typedef torrent::ConnectionList       connection_list_type;
   typedef download_type::ConnectionType connection_type;
 
+  static constexpr uint32_t default_resume_flags = ~uint32_t{} & ~torrent::Download::open_enable_fallocate;
+
   static const int variable_hashing_stopped = 0;
   static const int variable_hashing_initial = 1;
   static const int variable_hashing_last    = 2;
@@ -100,7 +102,7 @@ private:
   download_type       m_download;
   bool                m_hashFailed{};
   std::string         m_message;
-  uint32_t            m_resumeFlags{~uint32_t{}};
+  uint32_t            m_resumeFlags{default_resume_flags};
   unsigned int        m_group{};
 };
 

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -331,7 +331,7 @@ DownloadList::resume(Download* download, int flags) {
 
     // We need to make sure the flags aren't reset if someone decideds
     // to call resume() while it is hashing, etc.
-    if (download->resume_flags() == ~uint32_t())
+    if (download->resume_flags() == Download::default_resume_flags)
       download->set_resume_flags(flags);
 
     // Manual or end-of-download rehashing clears the resume data so
@@ -404,7 +404,7 @@ DownloadList::resume(Download* download, int flags) {
     download->set_priority(download->priority());
     download->download()->start(download->resume_flags());
 
-    download->set_resume_flags(~uint32_t());
+    download->set_resume_flags(Download::default_resume_flags);
 
     DL_TRIGGER_EVENT(download, "event.download.resumed");
 
@@ -421,7 +421,7 @@ DownloadList::pause(Download* download, int flags) {
 
   try {
 
-    download->set_resume_flags(~uint32_t());
+    download->set_resume_flags(Download::default_resume_flags);
 
     rpc::parse_command_single(rpc::make_target(download), "view.set_not_visible=active");
 
@@ -660,8 +660,8 @@ DownloadList::confirm_finished(Download* download) {
   if (find(infohash) == end())
     return;
 
-//   if (download->resume_flags() != ~uint32_t())
-//     throw torrent::internal_error("DownloadList::confirm_finished(...) download->resume_flags() != ~uint32_t().");
+//   if (download->resume_flags() != Download::default_resume_flags)
+//     throw torrent::internal_error("DownloadList::confirm_finished(...) download->resume_flags() != Download::default_resume_flags.");
 
   // See #1292.
   //
@@ -671,7 +671,7 @@ DownloadList::confirm_finished(Download* download) {
   //
   // TODO: Add a check when setting the flags to see if the torrent is
   // being hashed.
-  download->set_resume_flags(~uint32_t());
+  download->set_resume_flags(Download::default_resume_flags);
 
   if (!download->is_active() && rpc::call_command_value("d.state", rpc::make_target(download)) == 1)
     resume(download,


### PR DESCRIPTION
## Summary

Fixes a bug where `fallocate()` was called on files even when `system.file.allocate=0`, causing low-priority files (priority=0) to be fully preallocated on disk.

**Two-part fix**:
1. **rtorrent** (this PR): Define `Download::default_resume_flags` sentinel constant that masks out `open_enable_fallocate`, preventing the fallocate flag from being accidentally set at `open()` time.
2. **libtorrent**: Add priority check in `File::resize_file()` so priority=0 files are never preallocated regardless of `flag_fallocate`. See [rakshasa/libtorrent#753](https://github.com/rakshasa/libtorrent/pull/753).

## Root Cause

`m_resumeFlags` was initialized to `~uint32_t{}` (all bits set to 1). When `open_throw()` copies `resume_flags()` into `openFlags` before any explicit flags are set, the `open_enable_fallocate` bit was already 1, bypassing the `system.file.allocate=1` check. This caused `flag_fallocate` to be applied to all files regardless of config.

Additionally, even with correct flags, `resize_file()` did not check file priority before calling `allocate()`, so priority=0 files could still be preallocated.

## Changes

- `src/core/download.h` — Added `static constexpr uint32_t default_resume_flags = ~uint32_t{} & ~torrent::Download::open_enable_fallocate`
- `src/core/download_list.cc` — All `~uint32_t()` sentinel checks and reset calls use `Download::default_resume_flags`