### PR TITLE
[WIP] fix: ensure d.message is always set when hashing_failed

### DIFF
--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -494,8 +494,7 @@ DownloadList::hash_done(Download* download) {
     download->set_hash_failed(true);
 
     auto& msg = download->download()->hash_error_message();
-    if (!msg.empty())
-      download->set_message(msg);
+    download->set_message(msg.empty() ? "Hash check failed." : msg);
 
     DL_TRIGGER_EVENT(download, "event.download.hash_failed");
     return;

--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -513,8 +513,9 @@ Manager::receive_hashing_changed() {
 
       } else {
         (*itr)->set_hash_failed(true);
-        (*itr)->set_message("Hashing failed: " + std::string(e.what()));
-        lt_log_print(torrent::LOG_TORRENT_ERROR, "Hashing failed: %s", e.what());
+        const char* err_msg = e.what();
+        (*itr)->set_message(std::string("Hashing failed: ") + (err_msg && err_msg[0] ? err_msg : "unknown error."));
+        lt_log_print(torrent::LOG_TORRENT_ERROR, "Hashing failed: %s", err_msg ? err_msg : "(null)");
       }
     }
   }


### PR DESCRIPTION
## Summary

- Ensure `d.message` is always populated when `d.hashing_failed` is set, covering two remaining edge cases.

## Motivation

After [#1796](https://github.com/rakshasa/rtorrent/pull/1796), there are still cases where `hashing_failed=1` but `d.message` is empty:

1. **Hash check interrupted without I/O error** (e.g. download closed during hash check): `hash_error_message()` returns empty, so `d.message` was never set.
2. **`local_error` with empty `what()`**: Some `local_error` subclasses or the base class may return empty/null from `e.what()`, resulting in `"Hashing failed: "` with nothing after it.

## Changes

- `download_list.cc`: Always set `d.message` in the `!is_hash_checked()` branch, falling back to `"Hash check failed."` when `hash_error_message()` is empty.
- `manager.cc`: Handle empty/null `e.what()` in the `local_error` catch block, falling back to `"unknown error."`.