### PR TITLE
refactor: use torrent::heuristics_enum from types.h

### DIFF
--- a/src/command_download.cc
+++ b/src/command_download.cc
@@ -164,8 +164,8 @@ apply_d_connection_type(core::Download* download, const std::string& name) {
 
 torrent::Object
 apply_d_choke_heuristics(core::Download* download, const std::string& name, bool is_down) {
-  torrent::Download::HeuristicType t =
-    (torrent::Download::HeuristicType)torrent::option_find_string(torrent::OPTION_CHOKE_HEURISTICS, name.c_str());
+  torrent::heuristics_enum t =
+    static_cast<torrent::heuristics_enum>(torrent::option_find_string(torrent::OPTION_CHOKE_HEURISTICS, name.c_str()));
 
   if (is_down)
     download->download()->set_download_choke_heuristic(t);

--- a/src/command_groups.cc
+++ b/src/command_groups.cc
@@ -186,8 +186,8 @@ apply_cg_insert(const std::string& arg) {
   cg_list_hack.push_back(new torrent::choke_group());
   cg_list_hack.back()->set_name(arg);
 
-  cg_list_hack.back()->up_queue()->set_heuristics(torrent::choke_queue::HEURISTICS_UPLOAD_LEECH);
-  cg_list_hack.back()->down_queue()->set_heuristics(torrent::choke_queue::HEURISTICS_DOWNLOAD_LEECH);
+  cg_list_hack.back()->up_queue()->set_heuristics(torrent::HEURISTICS_UPLOAD_LEECH);
+  cg_list_hack.back()->down_queue()->set_heuristics(torrent::HEURISTICS_DOWNLOAD_LEECH);
 
   return torrent::Object();
 }


### PR DESCRIPTION
## Summary

- Use `torrent::heuristics_enum` from the new `torrent/download/types.h` instead of `choke_queue::heuristics_enum`
- Remove dependency on `choke_queue.h` for heuristics enum values

should be merged with https://github.com/rakshasa/libtorrent/pull/763