### PR TITLE
fix: remove HAVE_CXX11 check to fix std::function alignment crash

### DIFF
--- a/src/rpc/command.h
+++ b/src/rpc/command.h
@@ -160,16 +160,7 @@ protected:
   // within commands. E.d. callable command strings where one of the
   // arguments within the command needs to be supplied by the caller.
 
-#ifdef HAVE_CXX11
-  union {
-    base_function t_pod;
-    // char t_pod[sizeof(base_function)];
-  };
-#else
-  union {
-    char t_pod[sizeof(base_function)];
-  };
-#endif
+  base_function t_pod;
 };
 
 template <typename T1 = void, typename T2 = void>


### PR DESCRIPTION
## Summary

`HAVE_CXX11` was never defined in `configure.ac`, causing the `char t_pod[sizeof(base_function)]` branch to be used unconditionally. A `char[]` has 1-byte alignment while `std::function` requires 16-byte alignment on this platform, causing a misalignment crash on startup.

## Fix

Remove the `#ifdef HAVE_CXX11` / `#else` / `#endif` block entirely and directly declare `base_function t_pod` in the union, since C++20 is now required and `HAVE_CXX14` is already unconditionally 1 in `configure.ac`.