### PR TITLE
fix: std::function alignment crash with zig cc / libc++

### DIFF
--- a/src/command_dynamic.cc
+++ b/src/command_dynamic.cc
@@ -170,7 +170,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
 
     rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type>>::type>(
       raw_key,
-      std::bind(&rpc::object_storage::call_function_str, control->object_storage(), raw_key, std::placeholders::_1, std::placeholders::_2),
+      [storage = control->object_storage(), k = raw_key](auto target, const auto& obj) { return storage->call_function_str(k, target, obj); },
       &rpc::command_base_call<rpc::target_type>,
       cmd_flags,
       NULL,
@@ -179,7 +179,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
   } else {
     rpc::commands.insert_slot<rpc::command_base_is_type<rpc::command_base_call<rpc::target_type>>::type>(
       raw_key,
-      std::bind(&rpc::object_storage::get_str, control->object_storage(), raw_key),
+      [storage = control->object_storage(), k = raw_key](auto, const auto&) { return storage->get_str(k); },
       &rpc::command_base_call<rpc::target_type>,
       cmd_flags,
       NULL,

--- a/src/command_helpers.h
+++ b/src/command_helpers.h
@@ -69,17 +69,13 @@ void initialize_commands();
 
 #define CMD2_VAR_VALUE(key, value)                                      \
   control->object_storage()->insert_c_str(key, int64_t(value), rpc::object_storage::flag_value_type); \
-  CMD2_ANY(key, std::bind(&rpc::object_storage::get, control->object_storage(), \
-                               torrent::raw_string::from_c_str(key)));  \
-  CMD2_ANY_VALUE(key ".set", std::bind(&rpc::object_storage::set_value, control->object_storage(), \
-                                            torrent::raw_string::from_c_str(key), std::placeholders::_2));
+  CMD2_ANY(key, ([storage = control->object_storage(), k = torrent::raw_string::from_c_str(key)](auto, const auto&) { return storage->get(k); })); \
+  CMD2_ANY_VALUE(key ".set", ([storage = control->object_storage(), k = torrent::raw_string::from_c_str(key)](auto, const auto& v) { storage->set_value(k, v); return torrent::Object(); }));
 
 #define CMD2_VAR_STRING(key, value)                                     \
   control->object_storage()->insert_c_str(key, value, rpc::object_storage::flag_string_type); \
-  CMD2_ANY(key, std::bind(&rpc::object_storage::get, control->object_storage(), \
-                               torrent::raw_string::from_c_str(key)));  \
-  CMD2_ANY_STRING(key ".set", std::bind(&rpc::object_storage::set_string, control->object_storage(), \
-                                             torrent::raw_string::from_c_str(key), std::placeholders::_2));
+  CMD2_ANY(key, ([storage = control->object_storage(), k = torrent::raw_string::from_c_str(key)](auto, const auto&) { return storage->get(k); })); \
+  CMD2_ANY_STRING(key ".set", ([storage = control->object_storage(), k = torrent::raw_string::from_c_str(key)](auto, const auto& v) { storage->set_string(k, v); return torrent::Object(); }));
 
 
 #define CMD2_VAR_C_STRING(key, value)                                   \

--- a/src/rpc/command.h
+++ b/src/rpc/command.h
@@ -160,16 +160,7 @@ protected:
   // within commands. E.d. callable command strings where one of the
   // arguments within the command needs to be supplied by the caller.
 
-#ifdef HAVE_CXX11
-  union {
-    base_function t_pod;
-    // char t_pod[sizeof(base_function)];
-  };
-#else
-  union {
-    char t_pod[sizeof(base_function)];
-  };
-#endif
+  base_function t_pod;
 };
 
 template <typename T1 = void, typename T2 = void>


### PR DESCRIPTION
## Summary

Building with zig cc targeting x86_64-linux-gnu triggers alignment crashes during startup due to `std::function` storage requiring 16-byte alignment on this platform.

## Changes

1. **command.h**: Remove `#ifdef HAVE_CXX11` check so `t_pod` is always `base_function` (a `std::function` type with natural 16-byte alignment) instead of falling back to `char[]` (1-byte alignment). HAVE_CXX11 was never defined in configure.ac.

2. **command_dynamic.cc**: Replace `std::bind(&system_listMethods)` with a lambda — `std::bind` return objects can have stack alignment issues during RPC command registration.

3. **command_helpers.h**: Replace `std::bind` with lambdas in `CMD2_VAR_VALUE` and `CMD2_VAR_STRING` macros, which are used extensively during command initialization.

4. **command_dynamic.cc** (system_method_insert_object): Replace `std::bind` with lambdas for `call_function_str` and `get_str` command registration.