### PR TITLE
fix: define LUA_OK for Lua 5.1 and LuaJIT compatibility

### DIFF
--- a/src/rpc/lua.cc
+++ b/src/rpc/lua.cc
@@ -10,6 +10,10 @@
 
 #ifdef HAVE_LUA
 #include <lua.hpp>
+// LUA_OK was introduced in Lua 5.2; define for Lua 5.1 and LuaJIT2.0.
+#ifndef LUA_OK
+#define LUA_OK 0
+#endif
 #endif
 
 #include <torrent/object.h>


### PR DESCRIPTION
## Summary

- Define `LUA_OK` as 0 when it's not already defined, for compatibility with Lua 5.1 and LuaJIT (which is based on Lua 5.1)
- `LUA_OK` was introduced in Lua 5.2, so this define is needed when building against older Lua versions