### PR TITLE
main: register deprecated-command aliases unconditionally

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -353,7 +353,13 @@ main(int argc, char** argv) {
     //   Allow for use in config files, etc, just don't export it.
     // }
 
-    if (rpc::call_command_value("method.use_deprecated") == 1) {
+    // Deprecated-command aliases are registered unconditionally. Gating their
+    // registration on method.use_deprecated was a chicken-and-egg bug: that value is
+    // normally enabled from the config file (or by ruTorrent), but the config is parsed
+    // (parse_config_file, below) AFTER this point -- so config-based enabling never took
+    // effect; only the -D command-line flag did. Registering them unconditionally keeps
+    // them usable via `rtorrent -o import=<rc>` and ruTorrent, as in <= 0.16.13.
+    {
       CMD2_REDIRECT("execute2",         "execute");
       CMD2_REDIRECT("schedule2",        "schedule");
       CMD2_REDIRECT("schedule_remove2", "schedule.remove");


### PR DESCRIPTION
0.16.14 (commit 7537781) moved a batch of deprecated-command redirects (execute2, schedule2, bind, ip, port_range, dht, port_random, network.http.max_open, max_memory_usage, encoding_list, ...) inside an 'if (method.use_deprecated == 1)' guard in main(). That value is read during command registration, BEFORE parse_config_file() runs, and defaults to false; it can only be set early via the -D flag. So 'method.use_deprecated.set = true' in the rc has no effect on registration, and these aliases do not exist when the rc (or a front-end) uses them.

Net effect: 'rtorrent -o import=<file>' aborts at config-parse on any rc using a deprecated alias on a default invocation - a regression from <= 0.16.13, where the same block was unconditional (the guard was commented out). Register the aliases unconditionally via a plain scope block; they are cheap redirect entries and gating their registration on a value the config itself is meant to set is a chicken-and-egg bug.