### PR TITLE
GHA CI: enable libtorrent build flag matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,12 @@ jobs:
 
   ubuntu-base:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        libtorrent:
+          - libt_configure_flags: "--enable-openssl"
+          - libt_configure_flags: ""
     steps:
     - name: Update Packages
       run: |
@@ -15,7 +21,8 @@ jobs:
         sudo apt-get install -y \
           libcppunit-dev \
           zlib1g-dev \
-          libcurl4-openssl-dev
+          libcurl4-openssl-dev \
+          libssl-dev
     - name: Fetch libtorrent
       run: |
         git clone https://github.com/rakshasa/libtorrent
@@ -23,13 +30,13 @@ jobs:
       run: |
         cd libtorrent
         autoreconf -fiv
-        ./configure
+        ./configure ${{ matrix.libtorrent.libt_configure_flags }}
         make
         sudo make install DESTDIR=$GITHUB_WORKSPACE/libtorrent-dist
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: installed-libtorrent
+        name: installed-libtorrent-${{ matrix.libtorrent.libt_configure_flags == '' && 'default' || 'openssl' }}
         path: libtorrent-dist/
 
 
@@ -46,7 +53,7 @@ jobs:
     - name: Download Libtorrent Artifacts
       uses: actions/download-artifact@v4
       with:
-        name: installed-libtorrent
+        name: installed-libtorrent-default
         path: ./libtorrent-dist
     - name: Move Artifacts to System Path
       run: |
@@ -85,7 +92,7 @@ jobs:
     - name: Download Libtorrent Artifacts
       uses: actions/download-artifact@v4
       with:
-        name: installed-libtorrent
+        name: installed-libtorrent-default
         path: ./libtorrent-dist
     - name: Move Artifacts to System Path
       run: |


### PR DESCRIPTION
## Summary

- Restructures the `ubuntu-base` libtorrent build job to use a `libt_configure_flags` matrix variable
- Adds an `--enable-openssl` variant alongside the default build, exercising the flag-passing infrastructure
- Artifact names are made unique per matrix entry so downstream jobs can reference the correct build
- Mirrors the structural approach taken in [qbittorrent/qBittorrent#24564](https://github.com/qbittorrent/qBittorrent/pull/24564)

This paves the way for future WebTorrent related development: when rakshasa/libtorrent gains `--enable-webtorrent` support, adding it to CI will be a one-line matrix entry change.

> **Note:** rakshasa/libtorrent uses an autotools build system (`./configure`) rather than CMake, so the flag variable is `libt_configure_flags` rather than CMake `-D` flags. The pattern is otherwise identical to the qBittorrent approach.

## Test plan

- [ ] `ubuntu-base` builds libtorrent twice: default and `--enable-openssl`
- [ ] `unit-tests-default` and `unit-tests-variants` continue to pass using the `default` artifact
