### PR TITLE
Integrate WebTorrent support from libtorrent

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -29,7 +29,7 @@ jobs:
         autoconf -i
         autoheader
         automake --add-missing
-        ./configure
+        ./configure --disable-webtorrent
         make
         sudo make install
         cd ..
@@ -49,7 +49,7 @@ jobs:
         autoconf -i
         autoheader
         automake --add-missing
-        ./configure
+        ./configure --disable-webtorrent
     - name: Prepare compile_commands.json
       run: |
         bear -- make

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,18 @@ jobs:
 
   ubuntu-base:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        libtorrent:
+          - name: default
+            libtorrent_repo: rakshasa/libtorrent
+            libtorrent_ref: master
+            libt_configure_flags: --disable-webtorrent
+          - name: webtorrent
+            libtorrent_repo: kingomarwashere/libtorrent
+            libtorrent_ref: webtorrent-support
+            libt_configure_flags: --enable-webtorrent
     steps:
     - name: Update Packages
       run: |
@@ -15,21 +27,40 @@ jobs:
         sudo apt-get install -y \
           libcppunit-dev \
           zlib1g-dev \
-          libcurl4-openssl-dev
+          libcurl4-openssl-dev \
+          libssl-dev \
+          nlohmann-json3-dev \
+          pkg-config \
+          cmake
+    - name: Install libdatachannel
+      if: matrix.libtorrent.name == 'webtorrent'
+      run: |
+        if apt-cache show libdatachannel-dev >/dev/null 2>&1; then
+          sudo apt-get install -y libdatachannel-dev
+        else
+          git clone --recursive --depth 1 https://github.com/paullouisageneau/libdatachannel
+          cmake -S libdatachannel -B libdatachannel/build \
+            -DNO_EXAMPLES=ON \
+            -DNO_TESTS=ON \
+            -DUSE_GNUTLS=0
+          cmake --build libdatachannel/build --parallel
+          sudo cmake --install libdatachannel/build
+          sudo ldconfig
+        fi
     - name: Fetch libtorrent
       run: |
-        git clone https://github.com/rakshasa/libtorrent
+        git clone --branch "${{ matrix.libtorrent.libtorrent_ref }}" "https://github.com/${{ matrix.libtorrent.libtorrent_repo }}" libtorrent
     - name: Build libtorrent
       run: |
         cd libtorrent
         autoreconf -fiv
-        ./configure
+        ./configure ${{ matrix.libtorrent.libt_configure_flags }}
         make
         sudo make install DESTDIR=$GITHUB_WORKSPACE/libtorrent-dist
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: installed-libtorrent
+        name: installed-libtorrent-${{ matrix.libtorrent.name }}
         path: libtorrent-dist/
 
 
@@ -46,7 +77,7 @@ jobs:
     - name: Download Libtorrent Artifacts
       uses: actions/download-artifact@v4
       with:
-        name: installed-libtorrent
+        name: installed-libtorrent-default
         path: ./libtorrent-dist
     - name: Move Artifacts to System Path
       run: |
@@ -57,7 +88,7 @@ jobs:
     - name: Configure Project
       run: |
         autoreconf -fiv
-        ./configure
+        ./configure --disable-webtorrent
         make
         ls /usr/local/lib/
         LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib" make check
@@ -85,7 +116,7 @@ jobs:
     - name: Download Libtorrent Artifacts
       uses: actions/download-artifact@v4
       with:
-        name: installed-libtorrent
+        name: installed-libtorrent-default
         path: ./libtorrent-dist
     - name: Move Artifacts to System Path
       run: |
@@ -95,7 +126,37 @@ jobs:
     - name: Configure Project
       run: |
         autoreconf -fiv
-        ./configure ${{ matrix.config_flag }}
+        ./configure --disable-webtorrent ${{ matrix.config_flag }}
+        make
+        ls /usr/local/lib/
+        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib" make check
+
+  unit-tests-webtorrent:
+    runs-on: ubuntu-22.04
+    needs: ubuntu-base
+    steps:
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install -y \
+          libcppunit-dev \
+          zlib1g-dev \
+          libcurl4-openssl-dev \
+          libssl-dev \
+          nlohmann-json3-dev
+    - name: Download Libtorrent Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: installed-libtorrent-webtorrent
+        path: ./libtorrent-dist
+    - name: Move Artifacts to System Path
+      run: |
+        sudo cp -r ./libtorrent-dist/usr/local/* /usr/local/
+        rm -rf ./libtorrent-dist
+    - uses: actions/checkout@v4
+    - name: Configure Project
+      run: |
+        autoreconf -fiv
+        ./configure --enable-webtorrent
         make
         ls /usr/local/lib/
         LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib" make check

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,42 @@ PKG_CHECK_MODULES([CPPUNIT], [cppunit],, [no_cppunit="yes"])
 PKG_CHECK_MODULES([ZLIB], [zlib])
 PKG_CHECK_MODULES([DEPENDENCIES], [libtorrent >= 0.16.15])
 
+AC_ARG_ENABLE(webtorrent,
+  AS_HELP_STRING([--disable-webtorrent],
+    [disable WebTorrent support [[default=enable]]]),
+  [], [enable_webtorrent=yes])
+
+AS_IF([test "x$enable_webtorrent" != "xno"], [
+  AC_LANG_PUSH([C++])
+  rtorrent_save_CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS $DEPENDENCIES_CFLAGS"
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[
+        #include <torrent/common.h>
+        #include <torrent/peer/peer.h>
+        #include <torrent/runtime/runtime.h>
+        #ifndef LIBTORRENT_HAS_WEBTORRENT
+        #error "libtorrent was not built with WebTorrent support"
+        #endif
+      ]],
+      [[
+        bool supported = torrent::runtime::webtorrent_supported();
+        torrent::runtime::set_webtorrent_enabled(supported);
+        bool enabled = torrent::runtime::webtorrent_enabled();
+        torrent::tracker_enum tracker_type = torrent::TRACKER_WEBSOCKET;
+        torrent::Peer* peer = nullptr;
+        bool is_webtorrent = peer != nullptr && peer->is_webtorrent();
+        (void)enabled;
+        (void)tracker_type;
+        (void)is_webtorrent;
+      ]])],
+    [AC_DEFINE([HAVE_LIBUTORRENT_WEBTORRENT], [1], [Define if libtorrent exposes WebTorrent support.])],
+    [AC_MSG_ERROR([WebTorrent support requested but installed libtorrent does not expose the required WebTorrent API. Install a WebTorrent-enabled rakshasa/libtorrent or configure with --disable-webtorrent.])])
+  CXXFLAGS="$rtorrent_save_CXXFLAGS"
+  AC_LANG_POP([C++])
+])
+
 AC_LANG_PUSH(C++)
 TORRENT_WITH_XMLRPC_C
 AC_LANG_POP(C++)

--- a/doc/rtorrent.rc
+++ b/doc/rtorrent.rc
@@ -119,6 +119,13 @@
 #
 #protocol.pex.set = yes
 
+# Enable WebTorrent support when built against a WebTorrent-enabled
+# rakshasa/libtorrent. WebSocket trackers (ws:// and wss://) are handled by
+# libtorrent. Enabled by default when available.
+#
+#protocol.webtorrent.set = yes
+#protocol.webtorrent.set = no
+
 # Set download list layout style ("full", "compact").
 #
 #ui.torrent_list.layout.set = "full"

--- a/doc/rtorrent.rc-example
+++ b/doc/rtorrent.rc-example
@@ -30,6 +30,10 @@ network.port_random.set = no
 # (conservative settings for 'private' trackers, change for 'public')
 dht.mode.set = disable
 protocol.pex.set = no
+# WebTorrent requires a WebTorrent-enabled rakshasa/libtorrent. WebSocket
+# trackers (ws:// and wss://) are handled by libtorrent.
+#protocol.webtorrent.set = yes
+#protocol.webtorrent.set = no
 trackers.use_udp.set = no
 
 # Peer settings

--- a/doc/rtorrent.rc.lua-example
+++ b/doc/rtorrent.rc.lua-example
@@ -60,6 +60,10 @@ rc.network.port_random = false
 -- (conservative settings for 'private' trackers, change for 'public')
 rc.dht.mode = 'disable'
 rc.protocol.pex = false
+-- WebTorrent requires a WebTorrent-enabled rakshasa/libtorrent. WebSocket
+-- trackers (ws:// and wss://) are handled by libtorrent.
+--rc.protocol.webtorrent = true
+--rc.protocol.webtorrent = false
 rc.trackers.use_udp = false
 
 -- Peer settings

--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -201,6 +201,13 @@ initialize_command_local() {
   CMD_VAR_C_STRING("system.api_version",           (int64_t)API_VERSION);
   CMD_VAR_C_STRING("system.client_version",        PACKAGE_VERSION);
   CMD_VAR_C_STRING("system.library_version",       torrent::runtime::version());
+  CMD_VAR_C_STRING("system.has_webtorrent",
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+                   int64_t(1)
+#else
+                   int64_t(0)
+#endif
+                   );
 
   CMD_VAR_VALUE   ("system.file.allocate",         0);
   CMD_VAR_VALUE   ("system.file.max_size",         (int64_t)512 << 30);
@@ -344,6 +351,7 @@ initialize_command_local() {
 
   rpc::rpc.mark_safe("system.api_version");
   rpc::rpc.mark_safe("system.client_version");
+  rpc::rpc.mark_safe("system.has_webtorrent");
   rpc::rpc.mark_safe("system.library_version");
   rpc::rpc.mark_safe("system.file.max_size");
   rpc::rpc.mark_safe("system.file.split_size");

--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -61,6 +61,27 @@ apply_tos(const torrent::Object::string_type& arg) {
   return torrent::Object();
 }
 
+torrent::Object
+retrieve_protocol_webtorrent() {
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+  return int64_t(torrent::runtime::webtorrent_supported() && torrent::runtime::webtorrent_enabled());
+#else
+  return int64_t(0);
+#endif
+}
+
+torrent::Object
+apply_protocol_webtorrent(int64_t value) {
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+  torrent::runtime::set_webtorrent_enabled(value != 0);
+#else
+  if (value != 0)
+    throw torrent::input_error("WebTorrent support is not available in this build.");
+#endif
+
+  return torrent::Object();
+}
+
 void
 initialize_rpc_handlers() {
   rpc::rpc.initialize_handlers();
@@ -229,6 +250,8 @@ initialize_command_network() {
   CMD2_ANY_VALUE_V ("network.listen.backlog.set", [nw_config](auto, auto& value) { return nw_config->set_listen_backlog(value); });
 
   CMD2_VAR_BOOL    ("protocol.pex",               true);
+  CMD2_ANY         ("protocol.webtorrent",         [](auto, auto)        { return retrieve_protocol_webtorrent(); });
+  CMD2_ANY_VALUE_V ("protocol.webtorrent.set",     [](auto, auto& value) { return apply_protocol_webtorrent(value); });
   CMD2_ANY_LIST    ("protocol.encryption.set",    [](auto, auto& args)           { return apply_encryption(args); });
 
   CMD2_VAR_STRING  ("protocol.connection.leech",            "leech");
@@ -340,6 +363,7 @@ initialize_command_network() {
   rpc::rpc.mark_safe("network.proxy_address");
   rpc::rpc.mark_safe("network.scgi.dont_route");
   rpc::rpc.mark_safe("protocol.pex");
+  rpc::rpc.mark_safe("protocol.webtorrent");
 
   rpc::rpc.mark_safe("network.rpc.use_xmlrpc");
   rpc::rpc.mark_safe("network.rpc.use_jsonrpc");

--- a/src/command_peer.cc
+++ b/src/command_peer.cc
@@ -45,6 +45,24 @@ retrieve_p_completed_percent(torrent::Peer* peer) {
   return (100 * peer->bitfield()->size_set()) / peer->bitfield()->size_bits();
 }
 
+torrent::Object
+retrieve_p_is_webtorrent(torrent::Peer* peer) {
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+  return int64_t(peer->is_webtorrent());
+#else
+  return int64_t(0);
+#endif
+}
+
+torrent::Object
+retrieve_p_transport(torrent::Peer* peer) {
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+  return peer->is_webtorrent() ? std::string("webrtc") : std::string("tcp");
+#else
+  return std::string("tcp");
+#endif
+}
+
 void
 initialize_command_peer() {
   CMD2_PEER("p.id",                [](auto* peer, auto) { return torrent::utils::transform_to_hex_str(peer->id()); });
@@ -56,6 +74,8 @@ initialize_command_peer() {
   CMD2_PEER("p.is_encrypted",      std::bind(&torrent::Peer::is_encrypted, std::placeholders::_1));
   CMD2_PEER("p.is_incoming",       std::bind(&torrent::Peer::is_incoming, std::placeholders::_1));
   CMD2_PEER("p.is_obfuscated",     std::bind(&torrent::Peer::is_obfuscated, std::placeholders::_1));
+  CMD2_PEER("p.is_webtorrent",     std::bind(&retrieve_p_is_webtorrent, std::placeholders::_1));
+  CMD2_PEER("p.transport",         std::bind(&retrieve_p_transport, std::placeholders::_1));
   CMD2_PEER("p.is_snubbed",        std::bind(&torrent::Peer::is_snubbed, std::placeholders::_1));
 
   CMD2_PEER("p.is_unwanted",       std::bind(&torrent::PeerInfo::is_unwanted,  std::bind(&torrent::Peer::peer_info, std::placeholders::_1)));
@@ -96,6 +116,8 @@ initialize_command_peer() {
   rpc::rpc.mark_safe("p.is_encrypted");
   rpc::rpc.mark_safe("p.is_incoming");
   rpc::rpc.mark_safe("p.is_obfuscated");
+  rpc::rpc.mark_safe("p.is_webtorrent");
+  rpc::rpc.mark_safe("p.transport");
   rpc::rpc.mark_safe("p.is_snubbed");
   rpc::rpc.mark_safe("p.is_unwanted");
   rpc::rpc.mark_safe("p.is_preferred");

--- a/src/command_tracker.cc
+++ b/src/command_tracker.cc
@@ -79,6 +79,20 @@ apply_enable_trackers(int64_t arg) {
   return torrent::Object();
 }
 
+const char*
+tracker_type_name(torrent::tracker_enum type) {
+  switch (type) {
+  case torrent::TRACKER_HTTP: return "http";
+  case torrent::TRACKER_UDP: return "udp";
+  case torrent::TRACKER_DHT: return "dht";
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+  case torrent::TRACKER_WEBSOCKET: return "websocket";
+#endif
+  case torrent::TRACKER_NONE:
+  default: return "none";
+  }
+}
+
 void
 initialize_command_tracker() {
   CMD2_TRACKER        ("t.is_busy",            [](auto* tracker, auto) { return tracker->is_requesting(); });
@@ -99,6 +113,7 @@ initialize_command_tracker() {
   CMD2_TRACKER        ("t.url",                [](auto* tracker, auto) { return tracker->url(); });
   CMD2_TRACKER        ("t.group",              [](auto* tracker, auto) { return tracker->group(); });
   CMD2_TRACKER        ("t.type",               [](auto* tracker, auto) { return tracker->type(); });
+  CMD2_TRACKER        ("t.type_str",           [](auto* tracker, auto) { return std::string(tracker_type_name(tracker->type())); });
   CMD2_TRACKER        ("t.id",                 [](auto* tracker, auto) { return tracker->tracker_id(); });
 
   CMD2_TRACKER        ("t.latest_event",       [](auto* tracker, auto) { return tracker->state().latest_event(); });
@@ -151,6 +166,7 @@ initialize_command_tracker() {
   rpc::rpc.mark_safe("t.group");
   rpc::rpc.mark_safe("t.id");
   rpc::rpc.mark_safe("t.type");
+  rpc::rpc.mark_safe("t.type_str");
   rpc::rpc.mark_safe("t.is_usable");
   rpc::rpc.mark_safe("t.is_busy");
   rpc::rpc.mark_safe("t.is_enabled");

--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -213,7 +213,7 @@ DownloadFactory::receive_success() {
 
   rtorrent->insert_key("key", download->tracker_controller().key());
 
-  initialize_rtorrent(download, rtorrent);
+  initialize_rtorrent(download, rtorrent, resumeObject);
 
   if (!rtorrent->has_key_string("custom1")) rtorrent->insert_key("custom1", std::string());
   if (!rtorrent->has_key_string("custom2")) rtorrent->insert_key("custom2", std::string());
@@ -357,7 +357,7 @@ DownloadFactory::receive_failed(const std::string& msg) {
 }
 
 void
-DownloadFactory::initialize_rtorrent(Download* download, torrent::Object* rtorrent) {
+DownloadFactory::initialize_rtorrent(Download* download, torrent::Object* rtorrent, torrent::Object& resumeObject) {
   auto cached_seconds = torrent::this_thread::cached_seconds().count();
 
   if (!rtorrent->has_key_value("state") || rtorrent->get_key_value("state") > 1) {
@@ -392,8 +392,13 @@ DownloadFactory::initialize_rtorrent(Download* download, torrent::Object* rtorre
   if (rtorrent->has_key_value("total_downloaded"))
     download->info()->mutable_down_rate()->set_total(rtorrent->get_key_value("total_downloaded"));
 
-  if (rtorrent->has_key_value("chunks_done") && rtorrent->has_key_value("chunks_wanted"))
+  if (rtorrent->has_key_value("complete") && rtorrent->get_key_value("complete")) {
+    torrent::resume_load_progress(*download->download(), resumeObject);
+    download->download()->set_bitfield(true);
+
+  } else if (rtorrent->has_key_value("chunks_done") && rtorrent->has_key_value("chunks_wanted")) {
     download->download()->set_chunks_done(rtorrent->get_key_value("chunks_done"), rtorrent->get_key_value("chunks_wanted"));
+  }
 
   download->set_throttle_name(rtorrent->has_key_string("throttle_name")
                               ? rtorrent->get_key_string("throttle_name")

--- a/src/core/download_factory.h
+++ b/src/core/download_factory.h
@@ -60,7 +60,7 @@ private:
 
   void                log_created(Download* download, torrent::Object* rtorrent);
 
-  void                initialize_rtorrent(Download* download, torrent::Object* rtorrent);
+  void                initialize_rtorrent(Download* download, torrent::Object* rtorrent, torrent::Object& resumeObject);
 
   Manager*                       m_manager;
   std::shared_ptr<std::iostream> m_stream;

--- a/src/display/window_peer_list.cc
+++ b/src/display/window_peer_list.cc
@@ -32,6 +32,7 @@ WindowPeerList::redraw() {
   int y = 0;
 
   m_canvas->print(x, y, "IP");      x += 25;
+  m_canvas->print(x, y, "TR");      x += 4;
   m_canvas->print(x, y, "UP");      x += 7;
   m_canvas->print(x, y, "DOWN");    x += 7;
   m_canvas->print(x, y, "PEER");    x += 7;
@@ -72,6 +73,15 @@ WindowPeerList::redraw() {
                     range.first == *m_focus ? '*' : ' ',
                     ip_address.c_str());
     x += 27;
+
+    m_canvas->print(x, y, "%s",
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+                    p->is_webtorrent() ? "WT" : "--"
+#else
+                    "--"
+#endif
+                    );
+    x += 4;
 
     m_canvas->print(x, y, "%.1f", (double)p->up_rate()->rate() / 1024); x += 7;
     m_canvas->print(x, y, "%.1f", (double)p->down_rate()->rate() / 1024); x += 7;

--- a/src/display/window_tracker_list.cc
+++ b/src/display/window_tracker_list.cc
@@ -10,6 +10,24 @@
 
 namespace display {
 
+namespace {
+
+const char*
+tracker_type_name(torrent::tracker_enum type) {
+  switch (type) {
+  case torrent::TRACKER_HTTP: return "http";
+  case torrent::TRACKER_UDP: return "udp";
+  case torrent::TRACKER_DHT: return "dht";
+#ifdef HAVE_LIBUTORRENT_WEBTORRENT
+  case torrent::TRACKER_WEBSOCKET: return "websocket";
+#endif
+  case torrent::TRACKER_NONE:
+  default: return "none";
+  }
+}
+
+} // namespace
+
 WindowTrackerList::WindowTrackerList(core::Download* d, unsigned int* focus) :
   Window(new Canvas, 0, 0, 0, extent_full, extent_full),
   m_download(d),
@@ -60,8 +78,9 @@ WindowTrackerList::redraw() {
 
       auto tracker_state = tracker.state();
 
-      m_canvas->print(0, pos++, "%s Id: %s Counters: %uf / %us (%u) %s S/L/D: %u/%u/%u (%u/%u)",
+      m_canvas->print(0, pos++, "%s Type: %s Id: %s Counters: %uf / %us (%u) %s S/L/D: %u/%u/%u (%u/%u)",
                       state,
+                      tracker_type_name(tracker.type()),
                       torrent::utils::copy_escape_html_str(tracker.tracker_id()).c_str(),
                       tracker_state.failed_counter(),
                       tracker_state.success_counter(),

--- a/src/ui/download.cc
+++ b/src/ui/download.cc
@@ -137,6 +137,7 @@ Download::create_info() {
   element->push_back("");
   element->push_column("Connection type:",  te_command("cat=(d.connection_current),\" \",(if,(d.accepting_seeders),"",\"no_seeders\")"));
   element->push_column("Choke heuristic:",  te_command("cat=(d.up.choke_heuristics),\", \",(d.down.choke_heuristics),\", \",(d.group)"));
+  element->push_column("WebTorrent:",       te_command("if=$system.has_webtorrent=,$if=$protocol.webtorrent=,enabled,disabled,\"not built\""));
   element->push_column("Safe sync:",        te_command("if=$pieces.sync.always_safe=,yes,no"));
   element->push_column("Send buffer:",      te_command("cat=$convert.kb=$network.send_buffer.size=,\" KB\""));
   element->push_column("Receive buffer:",   te_command("cat=$convert.kb=$network.receive_buffer.size=,\" KB\""));

--- a/src/ui/element_peer_list.cc
+++ b/src/ui/element_peer_list.cc
@@ -110,6 +110,7 @@ ElementPeerList::create_info() {
   element->push_column("Id:",        te_command("p.id_html="));
   element->push_column("Client:",    te_command("p.client_version="));
   element->push_column("Options:",   te_command("p.options_str="));
+  element->push_column("Transport:", te_command("if=$p.is_webtorrent=,WebRTC,TCP"));
   element->push_column("Connected:", te_command("if=$p.is_incoming=,incoming,outgoing"));
   element->push_column("Encrypted:", te_command("if=$p.is_encrypted=,yes,$p.is_obfuscated=,handshake,no"));
 


### PR DESCRIPTION
## Summary

This wires rtorrent up as the configuration, UI, RPC, and CI consumer of WebTorrent support implemented in rakshasa/libtorrent.

The WebRTC, WebSocket tracker, signaling, SDP/ICE, and DataChannel transport logic remains in libtorrent. rtorrent only detects support, exposes user-facing controls/status, and displays WebTorrent tracker/peer state.

Depends on rakshasa/libtorrent#796.

## What Changed

- Add build-time WebTorrent integration:
  - `--enable-webtorrent` / default enabled
  - `--disable-webtorrent`
  - configure-time probe for the required libtorrent WebTorrent API
  - `HAVE_LIBUTORRENT_WEBTORRENT` only when the probe succeeds
  - rtorrent does not link `libdatachannel` directly; it consumes libtorrent through pkg-config

- Add RPC/config commands:
  - `system.has_webtorrent`
  - `protocol.webtorrent`
  - `protocol.webtorrent.set`
  - `p.is_webtorrent`
  - `p.transport`
  - `t.type_str`

- Mark safe RPC commands:
  - `system.has_webtorrent`
  - `protocol.webtorrent`
  - `p.is_webtorrent`
  - `p.transport`
  - `t.type_str`

- Add UI integration:
  - peer list `TR` column
    - `WT` for WebTorrent/WebRTC peers
    - `--` for TCP peers
  - peer detail view shows `Transport: WebRTC` or `TCP`
  - tracker list shows WebSocket trackers as `websocket`
  - download info panel shows WebTorrent state:
    - `enabled`
    - `disabled`
    - `not built`

- Add documentation examples:
  - `#protocol.webtorrent.set = yes`
  - `#protocol.webtorrent.set = no`
  - note that WebTorrent requires a WebTorrent-enabled rakshasa/libtorrent
  - note that `ws://` and `wss://` trackers are handled by libtorrent

- Update CI workflows:
  - add matrix fields for default/WebTorrent libtorrent builds
  - add rtorrent WebTorrent build path
  - add disabled WebTorrent build coverage

- Preserve completed-session seeding behavior:
  - restored complete torrents load resume progress and publish a full bitfield before WebTorrent peers connect

## Runtime Behavior

When built with WebTorrent-capable libtorrent:

- WebTorrent is enabled by default.
- `protocol.webtorrent.set = no` disables WebTorrent runtime behavior globally.
- `protocol.webtorrent.set = yes` re-enables it.
- `ws://` and `wss://` trackers are accepted and handled by libtorrent.

When built without WebTorrent-capable libtorrent:

- `system.has_webtorrent` returns `0`
- `protocol.webtorrent` returns `0`
- setting `protocol.webtorrent.set = yes` throws:
  - `WebTorrent support is not available in this build.`

## Compatibility

Existing TCP peer behavior and existing tracker behavior remain unchanged for:

- HTTP trackers
- HTTPS trackers
- UDP trackers
- DHT trackers

Existing peer rate/choke/snub/ban/disconnect behavior is unchanged.

## Testing

Tested locally on macOS against the matching libtorrent branch.

WebTorrent-enabled build:

- `./configure --enable-webtorrent`
- `make -j4`
- `make check`
  - 2/2 rtorrent tests passed

Disabled build against libtorrent built with `--disable-webtorrent`:

- `./configure --disable-webtorrent`
- `make -j4`
- `make check`
  - 2/2 rtorrent tests passed

End-to-end browser test:

- rtorrent seeded a fresh torrent with a `wss://tracker.btorrent.xyz:443` tracker
- browser WebTorrent client loaded the `.torrent`
- browser connected to rtorrent as a WebTorrent/WebRTC peer
- browser received the piece and completed the file

Also verified:

- `git diff --check` clean
- rtorrent + ruTorrent run successfully against the WebTorrent-enabled build
