### PR TITLE
Mark d.complete & d.timestamp.finished as safe

### DIFF
--- a/src/command_download.cc
+++ b/src/command_download.cc
@@ -972,6 +972,8 @@ initialize_command_download() {
   rpc::rpc.mark_safe("d.size_chunks");
   rpc::rpc.mark_safe("d.size_pex");
   rpc::rpc.mark_safe("d.completed_bytes");
+  rpc::rpc.mark_safe("d.complete");
+  rpc::rpc.mark_safe("d.timestamp.finished");
   rpc::rpc.mark_safe("d.bytes_done");
   rpc::rpc.mark_safe("d.peers_accounted");
   rpc::rpc.mark_safe("d.chunks_hashed");


### PR DESCRIPTION
Add `d.complete` & `d.timestamp.finished` in safe list of command_download.

To prevent those errors from Radarr, Sonarr and nzb360 clients on httprpc endpoint :
`Command "d.complete" is not allowed for untrusted connections.`
`Command "d.timestamp.finished" is not allowed for untrusted connections.`

May fix ;
https://github.com/crazy-max/docker-rtorrent-rutorrent/issues/564
https://github.com/Novik/ruTorrent/issues/3072