### PR TITLE
Add RISC-V cacheline fallbacks

### DIFF
--- a/scripts/common.m4
+++ b/scripts/common.m4
@@ -118,6 +118,10 @@ AC_DEFUN([TORRENT_CHECK_CACHELINE], [
             AC_MSG_RESULT([linux fallback enterprise 128 bytes])
             AC_DEFINE([LT_SMP_CACHE_BYTES], 128, [Fallback 128-byte alignment for Linux enterprise hardware.])
             ;;
+          riscv32*|riscv64*)
+            AC_MSG_RESULT([linux fallback RISC-V 64 bytes])
+            AC_DEFINE([LT_SMP_CACHE_BYTES], 64, [Fallback 64-byte alignment for Linux RISC-V hardware.])
+            ;;
           *)
             AC_MSG_RESULT([unrecognized CPU arch on Linux header fallback])
             AC_MSG_FAILURE([Unrecognized CPU architecture ($host_cpu) on Linux fallback path. Aborting build.])


### PR DESCRIPTION
The Linux cacheline probe first tries <linux/cache.h>, but that header is not part of the installed uapi headers on Arch Linux. When the compile probe fails, configure falls back to a host_cpu mapping and currently aborts for riscv64 with:

  Unrecognized CPU architecture (riscv64) on Linux fallback path.

Handle riscv* in both cacheline fallback maps and use a 64-byte cacheline. That matches the Linux RISC-V kernel default L1_CACHE_SHIFT value of 6 and the value reported on a riscv64 machine through getconf LEVEL1_DCACHE_LINESIZE and sysfs cache coherency_line_size.