### PR TITLE
Add encryption option parsing tests for require and allow_incoming

### DIFF
--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -34,13 +34,14 @@
 
 torrent::Object
 apply_encryption(const torrent::Object::list_type& args) {
-  uint32_t options_mask = torrent::runtime::NetworkConfig::encryption_none;
+  const uint32_t none = torrent::option_find_string(torrent::OPTION_ENCRYPTION, "none");
+  uint32_t options_mask = none;
 
   for (const auto& arg : args) {
     uint32_t opt = torrent::option_find_string(torrent::OPTION_ENCRYPTION, arg.as_string().c_str());
 
-    if (opt == torrent::runtime::NetworkConfig::encryption_none)
-      options_mask = torrent::runtime::NetworkConfig::encryption_none;
+    if (opt == none)
+      options_mask = none;
     else
       options_mask |= opt;
   }

--- a/test/rpc/test_parse_options.cc
+++ b/test/rpc/test_parse_options.cc
@@ -178,11 +178,17 @@ TestParseOptions::test_flag_libtorrent() {
 
 void
 TestParseOptions::test_flags_libtorrent() {
-  FLAGS_LT_ENCRYPTION_ASSERT("",                           torrent::runtime::NetworkConfig::encryption_none);
-  FLAGS_LT_ENCRYPTION_ASSERT("none",                       torrent::runtime::NetworkConfig::encryption_none);
-  FLAGS_LT_ENCRYPTION_ASSERT("require_rc4",                torrent::runtime::NetworkConfig::encryption_require_RC4);
-  FLAGS_LT_ENCRYPTION_ASSERT("require_RC4",                torrent::runtime::NetworkConfig::encryption_require_RC4);
-  FLAGS_LT_ENCRYPTION_ASSERT("require_RC4 | enable_retry", torrent::runtime::NetworkConfig::encryption_require_RC4 | torrent::runtime::NetworkConfig::encryption_enable_retry);
+  FLAGS_LT_ENCRYPTION_ASSERT("",                           torrent::option_find_string(torrent::OPTION_ENCRYPTION, "none"));
+  FLAGS_LT_ENCRYPTION_ASSERT("none",                       torrent::option_find_string(torrent::OPTION_ENCRYPTION, "none"));
+  FLAGS_LT_ENCRYPTION_ASSERT("require_rc4",                torrent::option_find_string(torrent::OPTION_ENCRYPTION, "require_rc4"));
+  FLAGS_LT_ENCRYPTION_ASSERT("require_RC4",                torrent::option_find_string(torrent::OPTION_ENCRYPTION, "require_RC4"));
+  FLAGS_LT_ENCRYPTION_ASSERT("require_RC4 | enable_retry", torrent::option_find_string(torrent::OPTION_ENCRYPTION, "require_RC4")
+                                                         | torrent::option_find_string(torrent::OPTION_ENCRYPTION, "enable_retry"));
+  FLAGS_LT_ENCRYPTION_ASSERT("require",                    torrent::option_find_string(torrent::OPTION_ENCRYPTION, "require"));
+  FLAGS_LT_ENCRYPTION_ASSERT("allow_incoming | enable_retry | prefer_plaintext",
+                             torrent::option_find_string(torrent::OPTION_ENCRYPTION, "allow_incoming")
+                           | torrent::option_find_string(torrent::OPTION_ENCRYPTION, "enable_retry")
+                           | torrent::option_find_string(torrent::OPTION_ENCRYPTION, "prefer_plaintext"));
 
   FLAGS_LT_ENCRYPTION_ASSERT_ERROR("require_");
 }


### PR DESCRIPTION
Add some tests to catch regressions.

https://github.com/rakshasa/libtorrent/pull/805

Complements libtorrent fix for encryption_require bitmask overlap.