### PR TITLE
Mark d.timestamp.started as safe

### DIFF
--- a/src/command_download.cc
+++ b/src/command_download.cc
@@ -974,6 +974,7 @@ initialize_command_download() {
   rpc::rpc.mark_safe("d.size_pex");
   rpc::rpc.mark_safe("d.completed_bytes");
   rpc::rpc.mark_safe("d.complete");
+  rpc::rpc.mark_safe("d.timestamp.started");
   rpc::rpc.mark_safe("d.timestamp.finished");
   rpc::rpc.mark_safe("d.bytes_done");
   rpc::rpc.mark_safe("d.peers_accounted");


### PR DESCRIPTION
Missed in #1853

Log after a [nzb360](https://play.google.com/store/apps/details?id=com.kevinforeman.nzb360) `d.multicall2` request on rtorrent `0.16.17` and rutorrent `5.3.7` :
```xml
<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><i8>-507</i8></value></member><member><name>faultString</name><value><string>Command "d.timestamp.started" is not allowed for untrusted connections.</string></value></member></struct></value></fault></methodResponse>
```