### PR TITLE
Restrict SCGI trust to local transports

### DIFF
--- a/doc/rtorrent.rc
+++ b/doc/rtorrent.rc
@@ -136,5 +136,6 @@
 # schedule can be used to set permissions on the unix socket.
 #
 #network.scgi.open_port = "127.0.0.1:5000"
+# TCP SCGI requests are untrusted. Use a Unix socket for trusted local control.
 #network.scgi.open_local = (cat,(session.path),/rpc.sock)
 #schedule2 = socket_chmod, 0, 0, "execute.nothrow=chmod,770,(cat,(session.path),/rpc.sock)"

--- a/src/rpc/rpc_manager.cc
+++ b/src/rpc/rpc_manager.cc
@@ -16,9 +16,9 @@ ExecFile   execFile;
 
 // Trusted/untrusted XMLRPC connection model.
 //
-// The trust state is set per-request by the SCGI layer based on the
-// UNTRUSTED_CONNECTION header. Commands without flag_untrusted_safe
-// are blocked for untrusted connections. The check is in
+// The SCGI listener establishes the trust state from its transport.
+// UNTRUSTED_CONNECTION may only reduce trust. Commands without
+// flag_untrusted_safe are blocked for untrusted connections. The check is in
 // CommandMap::call_command(), which catches all command execution
 // including nested calls through argument expansion.
 

--- a/src/rpc/rpc_manager.h
+++ b/src/rpc/rpc_manager.h
@@ -92,8 +92,8 @@ public:
 
   // Trusted/untrusted XMLRPC connection model.
   //
-  // When an SCGI request includes the UNTRUSTED_CONNECTION header,
-  // commands without flag_untrusted_safe are blocked.
+  // The SCGI transport determines trust. UNTRUSTED_CONNECTION can only
+  // reduce trust, and commands without flag_untrusted_safe are blocked.
   bool                is_trusted() const;
 
   static void         object_to_target(const torrent::Object& obj, int callFlags, rpc::target_type* target, std::function<void()>* deleter);

--- a/src/rpc/scgi.cc
+++ b/src/rpc/scgi.cc
@@ -33,6 +33,8 @@ SCgi::~SCgi() {
 
 void
 SCgi::open_port(sockaddr* sa, unsigned int length, bool dont_route) {
+  m_transport_trusted = false;
+
   int fd = torrent::fd_open_family(torrent::fd_flag_stream | torrent::fd_flag_nonblock | torrent::fd_flag_reuse_address,
                                    sa->sa_family);
 
@@ -53,6 +55,8 @@ SCgi::open_port(sockaddr* sa, unsigned int length, bool dont_route) {
 
 void
 SCgi::open_named(const std::string& filename) {
+  m_transport_trusted = true;
+
   if (filename.empty() || filename.size() >= sizeof(sockaddr_un::sun_path))
     throw torrent::resource_error("Invalid filename length.");
 
@@ -79,6 +83,14 @@ SCgi::open_named(const std::string& filename) {
 
 void
 SCgi::open_fd(int fd) {
+  sockaddr_storage sa{};
+  socklen_t length = sizeof(sa);
+
+  if (::getsockname(fd, reinterpret_cast<sockaddr*>(&sa), &length) == -1)
+    throw torrent::resource_error("Could not inspect systemd SCGI socket: " + std::string(std::strerror(errno)));
+
+  m_transport_trusted = sa.ss_family == AF_LOCAL;
+
   if (!torrent::fd_set_nonblock(fd))
     throw torrent::resource_error("Could not set non-blocking on systemd fd: " +
                                   std::string(std::strerror(errno)));
@@ -170,7 +182,7 @@ SCgi::event_read() {
     }
 
     auto open_func = [this, fd, task = m_current->get()]() {
-        task->open(this, fd);
+        task->open(this, fd, m_transport_trusted);
       };
 
     auto cleanup_func = [fd, task = m_current->get()](bool opened) {

--- a/src/rpc/scgi.h
+++ b/src/rpc/scgi.h
@@ -42,6 +42,7 @@ private:
 
   std::string         m_path;
   int                 m_logFd{-1};
+  bool                m_transport_trusted{false};
 
   task_list           m_tasks;
   task_list::iterator m_current;

--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -31,7 +31,7 @@ SCgiTask::SCgiTask()
 }
 
 void
-SCgiTask::open(SCgi* parent, int fd) {
+SCgiTask::open(SCgi* parent, int fd, bool trusted) {
   set_file_descriptor(fd);
 
   m_parent      = parent;
@@ -42,10 +42,7 @@ SCgiTask::open(SCgi* parent, int fd) {
   m_content_type        = XML;
   m_content_type_set    = false;
   m_accepts_compression = false;
-  m_trusted             = true;  // SCgiTask is pooled and reused; reset trust to default
-                                 // so a prior untrusted connection does not leak its
-                                 // m_trusted=false into the next reuse, given that the
-                                 // UNTRUSTED_CONNECTION=0 parse branch is a no-op.
+  m_trusted             = trusted;
 
   torrent::this_thread::poll()->open(this);
   torrent::this_thread::poll()->insert_read(this);
@@ -247,11 +244,9 @@ SCgiTask::parse_headers(const char* current, unsigned int header_length) {
     } else if (std::strncmp(key, "UNTRUSTED_CONNECTION", 20+1) == 0) {
       if (std::strncmp(value, "1", 1+1) == 0)
         m_trusted = false;
-      else if (std::strncmp(value, "0", 1+1) == 0)
-        m_trusted = true;  // Explicit reset (open() also resets, but be defensive in case
-                           // future refactors stop pooling tasks or skip the open() reset).
-      else
+      else if (std::strncmp(value, "0", 1+1) != 0)
         return false;
+      // A request header may reduce trust but must never grant it.
     }
   }
 

--- a/src/rpc/scgi_task.h
+++ b/src/rpc/scgi_task.h
@@ -25,7 +25,7 @@ public:
   bool                is_open() const      { return file_descriptor() != -1; }
   bool                is_available() const { return file_descriptor() == -1; }
 
-  void                open(SCgi* parent, int fd);
+  void                open(SCgi* parent, int fd, bool trusted);
   void                cancel_open();
 
   void                close();


### PR DESCRIPTION
TCP SCGI clients are trusted when they omit UNTRUSTED_CONNECTION, allowing a reachable listener to invoke privileged RPC methods such as execute.raw.

An unauthenticated network peer can execute an attacker-selected program as the rTorrent user.

Derive trust from the listener transport: TCP connections are untrusted, Unix-domain sockets remain trusted, and request headers can only reduce trust. Document the TCP restriction.