### PR TITLE
Update default encryption protocol settings.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -301,7 +301,7 @@ main(int argc, char** argv) {
        "schedule = low_diskspace,5,60,((close_low_diskspace,500M))\n"
        "schedule = prune_file_status,3600,86400,((system.file_status_cache.prune))\n"
 
-       "protocol.encryption.set=allow_incoming,prefer_plaintext,enable_retry\n"
+       "protocol.encryption.set=allow\n"
 
        "ui.color.focus.set=reverse\n"
     );


### PR DESCRIPTION
The current default, hard-coded encryption protocol settings are obsolete. This PR updates the settings to use the new options.

https://github.com/rakshasa/rtorrent/wiki/Protocol-Encryption-Configuration

> Default is `allow`, which defaults to plaintext while allowing encrypted handshake and message stream

---

Verified that the correct encryption options are set by running:

```
command> print=$protocol.encryption=
```

Resolves #1891