### PR TITLE
Support disabling upload traffic completely with '-1' throttle value.

### DIFF
--- a/doc/rtorrent.rc
+++ b/doc/rtorrent.rc
@@ -30,7 +30,7 @@
 #throttle.max_uploads.set = 15
 
 # Global upload and download rate in KiB.
-# "0" for unlimited.
+# "0" for unlimited, "-1" to disable all upload traffic.
 #
 #throttle.global_down.max_rate.set_kb = 0
 #throttle.global_up.max_rate.set_kb = 0

--- a/src/command_throttle.cc
+++ b/src/command_throttle.cc
@@ -173,7 +173,11 @@ initialize_command_throttle() {
   // TODO: Move the logic into some libtorrent function.
   CMD2_ANY         ("throttle.global_up.rate",              std::bind(&torrent::Rate::rate, torrent::up_rate()));
   CMD2_ANY         ("throttle.global_up.total",             std::bind(&torrent::Rate::total, torrent::up_rate()));
-  CMD2_ANY         ("throttle.global_up.max_rate",          std::bind(&torrent::Throttle::max_rate, torrent::up_throttle_global()));
+  CMD2_ANY         ("throttle.global_up.max_rate",          std::bind([]() -> int64_t {
+    if (control->ui() != nullptr && control->ui()->is_up_throttle_zero())
+      return (int64_t)0;
+    return (int64_t)torrent::up_throttle_global()->max_rate();
+  }));
   CMD2_ANY_VALUE_V ("throttle.global_up.max_rate.set",      std::bind(&ui::Root::set_up_throttle_i64, control->ui(), std::placeholders::_2));
   CMD2_ANY_VALUE_KB("throttle.global_up.max_rate.set_kb",   std::bind(&ui::Root::set_up_throttle_i64, control->ui(), std::placeholders::_2));
   CMD2_ANY         ("throttle.global_down.rate",            std::bind(&torrent::Rate::rate, torrent::down_rate()));

--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -194,6 +194,8 @@ Root::set_up_throttle(unsigned int throttle) {
   if (m_windowStatusbar != NULL)
     m_windowStatusbar->mark_dirty();
 
+  m_upThrottleZero = false;
+
   torrent::up_throttle_global()->set_max_rate(throttle * 1024);
 
   unsigned int div    = std::max<int>(rpc::call_command_value("throttle.max_uploads.div"), 0);
@@ -217,6 +219,40 @@ Root::set_up_throttle(unsigned int throttle) {
     torrent::resource_manager()->set_max_upload_unchoked(std::min(maxUnchoked, global));
   else
     torrent::resource_manager()->set_max_upload_unchoked(maxUnchoked);
+}
+
+void
+Root::set_down_throttle_i64(int64_t throttle) {
+  if (throttle < 0)
+    throttle = 0;
+
+  set_down_throttle(throttle >> 10);
+}
+
+void
+Root::set_up_throttle_i64(int64_t throttle) {
+  if (throttle < 0) {
+    set_up_throttle_zero();
+  } else {
+    m_upThrottleZero = false;
+    set_up_throttle(throttle >> 10);
+  }
+}
+
+void
+Root::set_up_throttle_zero() {
+  if (m_windowStatusbar != nullptr)
+    m_windowStatusbar->mark_dirty();
+
+  // 0 is "unlimited" in libtorrent, so we cannot use it for a true
+  // zero rate.  Set the rate to 1 byte/second, which is below the
+  // minimum chunk size, and reset the throttle so any queued quota
+  // is discarded.  This leaves upload slots open while ensuring no
+  // piece data is ever sent.
+  torrent::up_throttle_global()->set_max_rate(0);
+  torrent::up_throttle_global()->set_max_rate(1);
+
+  m_upThrottleZero = true;
 }
 
 void

--- a/src/ui/root.h
+++ b/src/ui/root.h
@@ -69,8 +69,10 @@ public:
   void                set_up_throttle(unsigned int throttle);
 
   // Rename to raw or something, make base function.
-  void                set_down_throttle_i64(int64_t throttle) { set_down_throttle(throttle >> 10); }
-  void                set_up_throttle_i64(int64_t throttle)   { set_up_throttle(throttle >> 10); }
+  void                set_down_throttle_i64(int64_t throttle);
+  void                set_up_throttle_i64(int64_t throttle);
+
+  bool                is_up_throttle_zero() const             { return m_upThrottleZero; }
 
   void                adjust_down_throttle(int throttle);
   void                adjust_up_throttle(int throttle);
@@ -103,6 +105,7 @@ public:
 
 private:
   void                setup_keys();
+  void                set_up_throttle_zero();
 
   Control*                      m_control{nullptr};
   std::unique_ptr<DownloadList> m_downloadList;
@@ -130,6 +133,8 @@ private:
 
   ThrottleNameList    m_throttle_up_names;
   ThrottleNameList    m_throttle_down_names;
+
+  bool                m_upThrottleZero{false};
 };
 
 }


### PR DESCRIPTION
Fixes #1885

Very simple change, does exactly what Transmission when max upload speed is set to '0', effectively throttling all uploads to 0kb/s (resulting in peers eventually timing out).