### PR TITLE
fix background execution

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -99,6 +99,7 @@ Control::cleanup() {
 
   m_ui->cleanup();
   m_core->cleanup();
+  rpc::execFile.cleanup();
 
   display::Canvas::erase_std();
   display::Canvas::refresh_std();
@@ -108,6 +109,7 @@ Control::cleanup() {
 
 void
 Control::cleanup_exception() {
+  rpc::execFile.cleanup();
   display::Canvas::cleanup();
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -115,14 +115,12 @@ main(int argc, char** argv) {
     // TODO: Create a fake thread object for initializing other processes and enabling logging.
     torrent::initialize_main_thread();
 
-    // Block SIGCHLD until all threads are created, then unblock on main-thread, to avoid SIGCHLD
-    // interrupting other threads.
-    //
-    // This means only main-thread can fork and wait for child processes.
-
     SignalHandler::set_block(SIGALRM);
     SignalHandler::set_block(SIGPIPE);
+
+    // SIGCHLD must stay blocked in all threads.
     SignalHandler::set_block(SIGCHLD);
+    rpc::execFile.initialize();
 
     // All signal handlers must restore errno if they return.
     SignalHandler::set_handler(SIGSEGV,  std::bind(&do_panic, SIGSEGV));
@@ -166,8 +164,6 @@ main(int argc, char** argv) {
 
     scgi::ThreadScgi::create_thread();
     session::ThreadSession::create_thread();
-
-    SignalHandler::set_unblock(SIGCHLD);
 
     // Initialize option handlers after libtorrent to ensure
     // torrent::ConnectionManager* are valid etc.
@@ -487,7 +483,10 @@ main(int argc, char** argv) {
     control->cleanup();
 
   } catch (torrent::internal_error& e) {
-    control->cleanup_exception();
+    if (control != nullptr)
+      control->cleanup_exception();
+    else
+      rpc::execFile.cleanup();
 
     std::cout << "rtorrent: caught torrent::internal_error: "
               << e.what() << std::endl
@@ -500,7 +499,10 @@ main(int argc, char** argv) {
     return -1;
 
   } catch (std::exception& e) {
-    control->cleanup_exception();
+    if (control != nullptr)
+      control->cleanup_exception();
+    else
+      rpc::execFile.cleanup();
 
     std::cout << "rtorrent: caught" << typeid(e).name() << " : " << e.what() << std::endl;
 

--- a/src/rpc/exec_file.cc
+++ b/src/rpc/exec_file.cc
@@ -4,11 +4,16 @@
 #include <cerrno>
 #include <cstring>
 #include <fcntl.h>
+#include <mutex>
+#include <pthread.h>
+#include <signal.h>
 #include <spawn.h>
 #include <string>
+#include <thread>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <torrent/exceptions.h>
 #include <torrent/net/fd.h>
 #include <torrent/system/thread.h>
 #include <torrent/system/types.h>
@@ -23,9 +28,140 @@ namespace rpc {
 
 // TODO: Access fd through torrent logging?
 
+ExecFile::~ExecFile() {
+  cleanup();
+}
+
+void
+ExecFile::initialize() {
+  sigset_t signal_mask;
+  int mask_status = pthread_sigmask(SIG_SETMASK, nullptr, &signal_mask);
+
+  if (mask_status != 0)
+    throw torrent::internal_error("ExecFile::initialize() failed to read the signal mask: " + std::string(std::strerror(mask_status)));
+
+  if (sigismember(&signal_mask, SIGCHLD) != 1)
+    throw torrent::internal_error("ExecFile::initialize() requires SIGCHLD to be blocked on the calling thread.");
+
+  // POSIX permits blocked, ignored signals to be discarded. Preserve them for
+  // sigwait() by setting a non-ignored handler, but keep it blocked.
+  struct sigaction action{};
+  sigemptyset(&action.sa_mask);
+  action.sa_handler = &ExecFile::sigchld_handler;
+  action.sa_flags   = SA_NOCLDSTOP | SA_RESTART;
+
+  if (::sigaction(SIGCHLD, &action, &m_previous_sigchld) == -1) {
+    int error_number = errno;
+    throw torrent::internal_error("ExecFile::initialize() failed to install the SIGCHLD handler: " + std::string(std::strerror(error_number)));
+  }
+
+  try {
+    m_reaper_thread = std::thread(&ExecFile::reaper, this);
+
+  } catch (...) {
+    ::sigaction(SIGCHLD, &m_previous_sigchld, nullptr);
+    throw;
+  }
+}
+
+void
+ExecFile::cleanup() noexcept {
+  if (!m_reaper_thread.joinable())
+    return;
+
+  {
+    std::lock_guard<std::mutex> lock(m_background_mutex);
+    m_reaper_stopping = true;
+  }
+
+  pthread_kill(m_reaper_thread.native_handle(), SIGCHLD);
+  m_reaper_thread.join();
+
+  ::sigaction(SIGCHLD, &m_previous_sigchld, nullptr);
+}
+
+std::size_t
+ExecFile::background_process_count() const {
+  std::lock_guard<std::mutex> lock(m_background_mutex);
+  return m_background_processes.size();
+}
+
+void
+ExecFile::sigchld_handler([[maybe_unused]] int signum) noexcept {
+}
+
+void
+ExecFile::reap_background_processes() noexcept {
+  auto itr = m_background_processes.begin();
+
+  while (itr != m_background_processes.end()) {
+    int   status{};
+    pid_t waited_pid;
+
+    do {
+      waited_pid = ::waitpid(*itr, &status, WNOHANG);
+    } while (waited_pid == -1 && errno == EINTR);
+
+    if (waited_pid == 0 || (waited_pid == -1 && errno != ECHILD)) {
+      ++itr;
+      continue;
+    }
+
+    itr = m_background_processes.erase(itr);
+  }
+}
+
+void
+ExecFile::reaper() {
+  sigset_t child_signal;
+  sigemptyset(&child_signal);
+  sigaddset(&child_signal, SIGCHLD);
+
+  while (true) {
+    // SIGCHLD remains blocked in this thread; sigwait() accepts it synchronously.
+    int received_signal{};
+    int wait_status;
+
+    do {
+      wait_status = ::sigwait(&child_signal, &received_signal);
+    } while (wait_status == EINTR);
+
+    if (wait_status != 0) [[unlikely]]
+      throw torrent::internal_error("ExecFile::reaper() sigwait failed: " + std::string(std::strerror(wait_status)));
+
+    std::lock_guard<std::mutex> lock(m_background_mutex);
+
+    reap_background_processes();
+
+    if (m_reaper_stopping)
+      break;
+  }
+}
+
 int
 ExecFile::execute(const char* file, char* const* argv, int flags) {
   assert(!((flags & flag_capture) && (flags & flag_background)));
+
+  std::unique_lock<std::mutex> background_lock;
+
+  if (flags & flag_background) {
+    background_lock = std::unique_lock<std::mutex>(m_background_mutex);
+
+    if (!m_reaper_thread.joinable() || m_reaper_stopping)
+      throw torrent::internal_error("ExecFile::execute() background process reaper is not running.");
+
+    // Reserve before spawning so an allocation failure can't leave an untracked child.
+    if (m_background_processes.size() == m_background_processes.max_size())
+      throw torrent::internal_error("ExecFile::execute() background process allocation failed.");
+
+    m_background_processes.reserve(m_background_processes.size() + 1);
+  }
+
+  // Reset the signal handlers/masks for the new process.
+  sigset_t spawn_signal_mask;
+  sigset_t spawn_signal_defaults;
+  sigemptyset(&spawn_signal_mask);
+  sigfillset(&spawn_signal_defaults);
 
   // Write the executed command and its parameters to the log fd.
   [[maybe_unused]] int result;
@@ -106,6 +242,10 @@ ExecFile::execute(const char* file, char* const* argv, int flags) {
 #endif
   }
 
+  posix_spawnattr_setsigmask(&attr, &spawn_signal_mask);
+  posix_spawnattr_setsigdefault(&attr, &spawn_signal_defaults);
+  spawn_flags |= POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF;
+
   posix_spawnattr_setflags(&attr, spawn_flags);
 
   pid_t child_pid{};
@@ -122,6 +262,14 @@ ExecFile::execute(const char* file, char* const* argv, int flags) {
       torrent::fd_close(pipe_1);
 
     throw torrent::input_error("ExecFile::execute() posix_spawn failed: " + torrent::system::errno_enum_str(spawn_status));
+  }
+
+  if (flags & flag_background) {
+    m_background_processes.push_back(child_pid);
+
+    // Make sure the process we just started hasn't already exited.
+    reap_background_processes();
+    background_lock.unlock();
   }
 
   if (flags & flag_capture) {

--- a/src/rpc/exec_file.h
+++ b/src/rpc/exec_file.h
@@ -1,6 +1,13 @@
 #ifndef RTORRENT_RPC_EXEC_FILE_H
 #define RTORRENT_RPC_EXEC_FILE_H
 
+#include <cstddef>
+#include <mutex>
+#include <signal.h>
+#include <string>
+#include <sys/types.h>
+#include <thread>
+#include <vector>
 #include <torrent/object.h>
 
 namespace rpc {
@@ -15,15 +22,34 @@ public:
   static constexpr int flag_capture      = 0x4;
   static constexpr int flag_background   = 0x8;
 
+  ExecFile() = default;
+  ~ExecFile();
+
+  void                initialize();
+  void                cleanup() noexcept;
+
   int                 log_fd() const     { return m_log_fd; }
   void                set_log_fd(int fd) { m_log_fd = fd; }
 
   int                 execute(const char* file, char* const* argv, int flags);
   torrent::Object     execute_object(const torrent::Object& rawArgs, int flags);
 
+  std::size_t         background_process_count() const;
+
 private:
+  static void         sigchld_handler(int signum) noexcept;
+
+  void                reap_background_processes() noexcept;
+  void                reaper();
+
   int                 m_log_fd{-1};
   std::string         m_capture;
+
+  mutable std::mutex  m_background_mutex;
+  std::vector<pid_t>  m_background_processes;
+  std::thread         m_reaper_thread;
+  bool                m_reaper_stopping{};
+  struct sigaction    m_previous_sigchld{};
 };
 
 }


### PR DESCRIPTION
Taking another stab at https://github.com/rakshasa/rtorrent/issues/1848

Dropping the double fork() means background processes don't get reparented to init, which means we need to do something about them.

My two cents, the best option would be adding process tracking to the event loop (pidfd_open/EVFILT_PROC), but pidfd_open doesn't exist before linux 5.3. I don't know if you have a support window you care about.

As before, this version adds a reaper thread to wait on background processes. This version switches a signal handler for sigwait(), which behaves a little more pleasantly. It does install a (dummy) signal handler so that macOS doesn't just drop the signals, but the handler is never called. This version also maintains a pid list and waits only for what it spawns.

It also fixes another bug, where children of rtorrent were inheriting its signal settings instead of the defaults.