### PR TITLE
commands: fix group.<name>.ratio.disable calling a removed command

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -117,7 +117,7 @@ group_insert(const torrent::Object::list_type& args) {
   rpc::commands.call("method.insert", rpc::create_object_list("group." + name + ".ratio.enable", "simple",
                                                               "schedule=group." + name + ".ratio,5,60,on_ratio=" + name));
   rpc::commands.call("method.insert", rpc::create_object_list("group." + name + ".ratio.disable", "simple",
-                                                              "schedule_remove=group." + name + ".ratio"));
+                                                              "schedule.remove=group." + name + ".ratio"));
   rpc::commands.call("method.insert", rpc::create_object_list("group."  + name + ".ratio.command", "simple",
                                                               "d.try_close= ;d.ignore_commands.set=1"));
   rpc::commands.call("method.insert", rpc::create_object_list("group." + name + ".view", "string", view));


### PR DESCRIPTION
group_insert() builds the disable method as "schedule_remove=...", but that command no longer exists: the current name is schedule.remove, and the only old-style aliases registered are schedule2 and schedule_remove2 (and those only when deprecated commands are enabled at registration time). Every group.<name>.ratio.disable therefore faults with

Command "schedule_remove" does not exist.

including the built-in group.seeding.ratio.disable, so a ratio group can be enabled but never disabled. The enable half already uses the current name.