### PR TITLE
commands: don't register min_alloc/max_alloc for the generic socket category

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -250,12 +250,12 @@ initialize_command_local() {
 
     CMD_ANY        (category_name + ".size",      [category](auto, auto) { return torrent::runtime::socket_manager()->category_managed_size(category); });
     CMD_ANY        (category_name + ".max_size",  [category](auto, auto) { return torrent::runtime::socket_manager()->category_max_size(category); });
-    CMD_ANY        (category_name + ".min_alloc", [category](auto, auto) { return torrent::runtime::socket_manager()->category_min_allocation(category); });
-    CMD_ANY        (category_name + ".max_alloc", [category](auto, auto) { return torrent::runtime::socket_manager()->category_max_allocation(category); });
 
     if (i == 0)
       continue;
 
+    CMD_ANY        (category_name + ".min_alloc",     [category](auto, auto) { return torrent::runtime::socket_manager()->category_min_allocation(category); });
+    CMD_ANY        (category_name + ".max_alloc",     [category](auto, auto) { return torrent::runtime::socket_manager()->category_max_allocation(category); });
     CMD_ANY_VALUE_V(category_name + ".min_alloc.set", [category](auto, auto& value) { torrent::runtime::socket_manager()->set_category_min_allocation(category, value); });
     CMD_ANY_VALUE_V(category_name + ".max_alloc.set", [category](auto, auto& value) { torrent::runtime::socket_manager()->set_category_max_allocation(category, value); });
   }
@@ -354,6 +354,10 @@ initialize_command_local() {
 
     rpc::rpc.mark_safe(category_name + ".size");
     rpc::rpc.mark_safe(category_name + ".max_size");
+
+    if (i == 0)
+      continue;
+
     rpc::rpc.mark_safe(category_name + ".min_alloc");
     rpc::rpc.mark_safe(category_name + ".max_alloc");
   }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -49,6 +49,8 @@ rtorrent_Test_Rpc_SOURCES = $(rtorrent_Test_Common) \
 rtorrent_Test_Src_SOURCES = $(rtorrent_Test_Common) \
 	src/test_command_dynamic.cc \
 	src/test_command_dynamic.h \
+	src/test_command_local.cc \
+	src/test_command_local.h \
 	src/test_watch_ready_queue.cc \
 	src/test_watch_ready_queue.h
 

--- a/test/src/test_command_local.cc
+++ b/test/src/test_command_local.cc
@@ -1,0 +1,54 @@
+#include "config.h"
+
+#include "test/src/test_command_local.h"
+
+#include <torrent/torrent.h>
+#include <torrent/runtime/socket_manager.h>
+#include <torrent/utils/option_strings.h>
+
+#include "control.h"
+#include "globals.h"
+#include "rpc/parse_commands.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestCommandLocal);
+
+void initialize_command_local();
+
+void
+TestCommandLocal::setUp() {
+  torrent::initialize_main_thread();
+  torrent::initialize();
+
+  if (control == nullptr)
+    control = new Control;
+
+  if (!rpc::commands.has("system.sockets.size"))
+    initialize_command_local();
+}
+
+void
+TestCommandLocal::tearDown() {
+  torrent::cleanup();
+}
+
+void
+TestCommandLocal::test_socket_category_commands() {
+  for (uint32_t i = 0; i < torrent::runtime::SocketManager::category_count; ++i) {
+    auto category = static_cast<torrent::runtime::socket_manager_category_t>(i);
+    auto name     = "system.sockets." + torrent::option_to_str_or_throw(torrent::OPTION_SOCKET_CATEGORY, i);
+
+    for (const auto suffix : {".size", ".max_size", ".min_alloc", ".max_alloc"})
+      if (rpc::commands.has(name + suffix))
+        CPPUNIT_ASSERT_NO_THROW(rpc::commands.call(name + suffix));
+
+    const bool has_allocation = category != torrent::runtime::category_generic;
+
+    CPPUNIT_ASSERT(rpc::commands.has(name + ".size"));
+    CPPUNIT_ASSERT(rpc::commands.has(name + ".max_size"));
+
+    CPPUNIT_ASSERT_EQUAL(has_allocation, rpc::commands.has(name + ".min_alloc"));
+    CPPUNIT_ASSERT_EQUAL(has_allocation, rpc::commands.has(name + ".max_alloc"));
+    CPPUNIT_ASSERT_EQUAL(has_allocation, rpc::commands.has(name + ".min_alloc.set"));
+    CPPUNIT_ASSERT_EQUAL(has_allocation, rpc::commands.has(name + ".max_alloc.set"));
+  }
+}

--- a/test/src/test_command_local.h
+++ b/test/src/test_command_local.h
@@ -1,0 +1,15 @@
+#include "test/helpers/test_fixture.h"
+
+class TestCommandLocal : public test_fixture {
+  CPPUNIT_TEST_SUITE(TestCommandLocal);
+
+  CPPUNIT_TEST(test_socket_category_commands);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp();
+  void tearDown();
+
+  void test_socket_category_commands();
+};


### PR DESCRIPTION
Note: Unsure this is the best solution, but the crashes are real.

 `system.sockets.generic.min_alloc` and `system.sockets.generic.max_alloc` terminate  the process when called.

  `initialize_command_local()` registers `.size`, `.max_size`, `.min_alloc` and  `.max_alloc` for all five socket categories; the `if (i == 0) continue;` only skips  the `.set` variants. But `SocketManager::category_min_allocation()` and  `category_max_allocation()` throw `internal_error` for `category_generic`, and that  escapes through the XMLRPC dispatch:

```
      Caught internal_error: 'SocketManager::category_max_allocation(): invalid category'
      ... libxmlrpc_server.so.3(xmlrpc_dispatchCall+0xe8) ...

```

  Both commands are also `mark_safe`d, so this is reachable from untrusted connections — verified with an SCGI request carrying `UNTRUSTED_CONNECTION: 1`, which killed the daemon.

  The throw looks intentional: `adjust_allocation_unsafe()` calls `set_category()` only for internal/http/rpc/files and then assigns generic the remainder, so  `m_category_min_alloc[generic]` / `m_category_max_alloc[generic]` are never read.  Returning 0 instead would be misleading, since `can_open_socket_unsafe()` treats  `max_size == 0` as unlimited. So the fix is to not register the two getters for the generic category, matching what the existing guard already does for the setters.

  After the change both names are absent from `system.listMethods` and return  `-506 Method '...' not defined` (trusted and untrusted) with the process alive.  `system.sockets.generic.size` and `.max_size` are unaffected, as are all four  real categories' getters and setters.

  Includes a unit test that walks every category's socket commands and asserts the alloc commands exist iff the category is not generic. It fails on the current code (`internal_error` escaping `CPPUNIT_ASSERT_NO_THROW`) and passes with the fix.  Note it needs a real `torrent::initialize()` in `setUp` — `initialize_command_local()`  touches `torrent::file_manager()` — so it spawns the worker threads, and it will  fail where `ulimit -n < 512`. Happy to drop the test or make it lighter if you'd  prefer the fix on its own.