### PR TITLE
Fix zombie processes from background execute commands.

### DIFF
--- a/src/rpc/exec_file.cc
+++ b/src/rpc/exec_file.cc
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cerrno>
 #include <cstring>
@@ -23,9 +24,18 @@ namespace rpc {
 
 // TODO: Access fd through torrent logging?
 
+void
+ExecFile::reap_background_processes() {
+  m_background_pids.erase(std::remove_if(m_background_pids.begin(), m_background_pids.end(),
+                                         [](pid_t pid) { return ::waitpid(pid, nullptr, WNOHANG) != 0; }),
+                          m_background_pids.end());
+}
+
 int
 ExecFile::execute(const char* file, char* const* argv, int flags) {
   assert(!((flags & flag_capture) && (flags & flag_background)));
+
+  reap_background_processes();
 
   // Write the executed command and its parameters to the log fd.
   [[maybe_unused]] int result;
@@ -148,6 +158,8 @@ ExecFile::execute(const char* file, char* const* argv, int flags) {
   }
 
   if (flags & flag_background) {
+    m_background_pids.push_back(child_pid);
+
     if (m_log_fd != -1)
       result = write(m_log_fd, "\n--- Running in Background ---\n", sizeof("\n--- Running in Background ---\n"));
 

--- a/src/rpc/exec_file.h
+++ b/src/rpc/exec_file.h
@@ -1,6 +1,9 @@
 #ifndef RTORRENT_RPC_EXEC_FILE_H
 #define RTORRENT_RPC_EXEC_FILE_H
 
+#include <sys/types.h>
+#include <vector>
+
 #include <torrent/object.h>
 
 namespace rpc {
@@ -22,8 +25,11 @@ public:
   torrent::Object     execute_object(const torrent::Object& rawArgs, int flags);
 
 private:
+  void                reap_background_processes();
+
   int                 m_log_fd{-1};
   std::string         m_capture;
+  std::vector<pid_t>  m_background_pids;
 };
 
 }


### PR DESCRIPTION
Since the posix_spawn conversion, background execute children are never waited on and SIGCHLD keeps its default disposition, so every execute.throw.bg / execute.nothrow.bg call leaves a permanent zombie. 

SignalHandler::set_sigchild_ignore() exists but is never called — and wiring it would break the foreground path: SA_NOCLDWAIT auto-reap races the blocking waitpid(), which then fails with ECHILD and loses the exit status.

This tracks background pids and reaps them with waitpid(WNOHANG) at the next execute call, keeping all spawning and waiting on the main thread.

Repro: execute.nothrow.bg={sleep,1} → permanent <defunct> child. Verified: zombies reaped on the next execute; still-running background children unaffected; foreground exit status, execute.throw and execute.capture behavior unchanged.
