### PR TITLE
Fix deprecated command redirects (rtorrent -D)

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -392,13 +392,12 @@ main(int argc, char** argv) {
 
       CMD_REDIRECT("bind",                  "network.bind_address.set");
       CMD_REDIRECT("ip",                    "network.local_address.set");
-      CMD_REDIRECT("port_range",            "network.port_range.set");
 
       // TODO: Check if dht is on by default.
       CMD_REDIRECT("dht",                   "dht.mode.set");
 
-      CMD_REDIRECT("port_random",           "network.port_random.set");
-      CMD_REDIRECT("proxy_address",         "network.proxy_address.set");
+      CMD_REDIRECT("port_random",           "network.listen.port.random.set");
+      CMD_REDIRECT("proxy_address",         "network.proxy.http.set");
 
       CMD_REDIRECT("key_layout",            "keys.layout.set");
 


### PR DESCRIPTION
Before this, rtorrent failed to start with -D with errors like:

    Tried to redirect to a key that doesn't exist: 'network.port_range.set'

I updated the redirects for "port_random" and "proxy_address", but removed "port_range" since it's already defined unconditionally on line 347 above.