### PR TITLE
Update config files in doc with newer network.listen

### DIFF
--- a/doc/rtorrent.rc
+++ b/doc/rtorrent.rc
@@ -71,11 +71,11 @@
 
 # Port range to use for listening.
 #
-#network.port_range.set = 6890-6999
+#network.listen.port.range.set = 6890-6999
 
 # Start opening ports at a random position within the port range.
 #
-#network.port_random.set = no
+#network.listen.port.random.set = no
 
 # Set RPC type
 #network.rpc.use_xmlrpc.set = true

--- a/doc/rtorrent.rc-example
+++ b/doc/rtorrent.rc-example
@@ -23,8 +23,8 @@ execute.throw = sh, -c, (cat,\
     "\"",(cfg.watch),"/start\" ")
 
 # Listening port for incoming peer traffic (fixed; you can also randomize it)
-network.port_range.set = 50000-50000
-network.port_random.set = no
+network.listen.port.range.set = 50000-50000
+network.listen.port.random.set = no
 
 # Tracker-less torrent and UDP tracker support
 # (conservative settings for 'private' trackers, change for 'public')


### PR DESCRIPTION
Since the configuration options have changed in 0.16.18, this PR updates the doc config files with the newer keys