### PR TITLE
Add system.sockets.<category>.max_alloc_limit.

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -258,6 +258,7 @@ initialize_command_local() {
       continue;
     }
 
+    CMD_ANY        (category_name + ".max_alloc.limit", [category](auto, auto) { return torrent::runtime::socket_manager()->category_alloc_limit(category); });
     CMD_ANY        (category_name + ".min_alloc",     [category](auto, auto) { return torrent::runtime::socket_manager()->category_min_allocation(category); });
     CMD_ANY        (category_name + ".max_alloc",     [category](auto, auto) { return torrent::runtime::socket_manager()->category_max_allocation(category); });
     CMD_ANY_VALUE_V(category_name + ".min_alloc.set", [category](auto, auto& value) { torrent::runtime::socket_manager()->set_category_min_allocation(category, value); });
@@ -370,6 +371,7 @@ initialize_command_local() {
       continue;
     }
 
+    rpc::rpc.mark_safe(category_name + ".max_alloc.limit");
     rpc::rpc.mark_safe(category_name + ".min_alloc");
     rpc::rpc.mark_safe(category_name + ".max_alloc");
   }


### PR DESCRIPTION
Depends on rakshasa/libtorrent#870, which adds `SocketManager::category_alloc_limit()`. CI here stays red until that merges, since the workflow builds libtorrent master.

  A category can have a ceiling below the shared budget: http is capped at what the curl stack accepts, well under what `system.sockets.available_alloc` reports. Nothing exposes that, so a client has no way to know what it may set — it can only submit a value and see what happens. Until libtorrent#870 that did not even fail cleanly; it aborted the process.

  This registers `system.sockets.<category>.max_alloc_limit` for the four configurable categories, alongside the existing `min_alloc`/`max_alloc`, and marks it safe (read-only, no arguments, cannot throw).

  With libtorrent#870 applied, on a box with `ulimit -n 76000`:

  ```
  system.sockets.available_alloc         = 63192
  system.sockets.http.max_alloc_limit    = 4096
  system.sockets.files.max_alloc_limit   = 1000000
  system.sockets.rpc.max_alloc_limit     = 1000000
  system.sockets.internal.max_alloc_limit= 1000000
  ```

  A client can then offer the real range for each field instead of guessing. ruTorrent reads these two values to show the limit next to "maximum number of open files" and "maximum number of open HTTP connections" and to refuse a write that cannot fit, rather than sending one rtorrent will reject.

  Answering over an `UNTRUSTED_CONNECTION: 1` request was checked, with the process still running afterwards.