### PR TITLE
Fix garbage throttle values in the status bar on 32-bit archs

### DIFF
--- a/src/display/utils.cc
+++ b/src/display/utils.cc
@@ -345,7 +345,7 @@ print_status_info(char* first, char* last) {
   if (!torrent::up_throttle_global()->is_throttled()) {
     first = print_buffer(first, last, "[Throttle off");
   } else {
-    first = print_buffer(first, last, "[Throttle %3i", torrent::up_throttle_global()->max_rate() / 1024);
+    first = print_buffer(first, last, "[Throttle %3i", (int)(torrent::up_throttle_global()->max_rate() / 1024));
 
     if (!throttle_up_names.empty())
       first = print_status_throttle_limit(first, last, true, throttle_up_names);
@@ -354,7 +354,7 @@ print_status_info(char* first, char* last) {
   if (!torrent::down_throttle_global()->is_throttled()) {
     first = print_buffer(first, last, " / off KB]");
   } else {
-    first = print_buffer(first, last, " / %3i", torrent::down_throttle_global()->max_rate() / 1024);
+    first = print_buffer(first, last, " / %3i", (int)(torrent::down_throttle_global()->max_rate() / 1024));
 
     if (!throttle_down_names.empty())
       first = print_status_throttle_limit(first, last, false, throttle_down_names);


### PR DESCRIPTION
Closes #1683.

`Throttle::max_rate()` returns `uint64_t`, but both status bar call sites format it with `%3i`:

```cpp
first = print_buffer(first, last, "[Throttle %3i", torrent::up_throttle_global()->max_rate() / 1024);
first = print_buffer(first, last, " / %3i",        torrent::down_throttle_global()->max_rate() / 1024);
```

Passing a 64-bit value where the conversion specifier expects `int` is undefined, and it breaks in a way that depends on the calling convention:

- On x86-64 the argument sits in a register and `%i` reads its low half, so the right number comes out by luck. The reporter confirms his x86-64 box shows correct values with the same `.rtorrent.rc`.
- On armv7l a 64-bit variadic argument has to be 8-byte aligned, so it skips `r3` and goes on the stack. `%i` then reads the skipped `r3`, which holds whatever was left there.

That accounts for all three symptoms in the report: the numbers are garbage, they change on every status bar update, and up and down show the *same* garbage because the two call sites have identical shape and land on the same slot.

So this is not the compiler emitting bad instructions for 64-bit math, it is undefined behaviour in rtorrent that x86-64 happens to tolerate.

## Why nothing warned about it

`print_buffer` is a template that forwards a runtime format string to `snprintf`, so `-Wformat` cannot check any of its call sites. Calling `snprintf` directly with the same types shows what is being missed:

```
warning: format specifies type 'int' but the argument has type 'uint64_t'
    snprintf(buf, 64, "[Throttle %3i", max_rate / 1024);
                                 ~~~   ^~~~~~~~~~~~~~~
                                 %3llu
```

## The fix

Cast to `int` so the argument matches the specifier. A KB/s rate large enough to overflow `int` would be about 2 TB/s.

I checked the other integer conversions in `print_status_info` and `print_status_extra` while I was here. The unchoked counts are `unsigned int`, the socket manager values and `total_handshakes()` are `uint32_t`, and `FileManager::size_type` is `uint32_t`, so those all match in width and differ at most in signedness. These two were the only width mismatches, and they are exactly the two fields reported as broken.

## Testing

`make check` passes. Built and ran with the reporter's throttle settings:

```
throttle.global_down.max_rate.set_kb = 400
throttle.global_up.max_rate.set_kb = 30
```

```
[Throttle  30 / 400 KB] [Rate   0.0 /   0.0 KB]
```

The other two render paths still work:

```
[Throttle off / off KB]      # neither throttled
[Throttle  30 / off KB]      # up throttled only
```

One caveat worth stating plainly: I have no 32-bit ARM machine, so this is a static fix plus a no-regression check on 64-bit, where the output is unchanged either way. @tomasmez if you are able to build this branch on the Pi, that would confirm the numbers come out right.
