### PR TITLE
Link against libatomic when 64-bit atomics require it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,8 @@ RAK_ENABLE_DEBUG
 RAK_ENABLE_EXTRA_DEBUG
 RAK_ENABLE_WERROR
 
+TORRENT_CHECK_ATOMIC
+
 AC_ARG_ENABLE(execinfo,
   AS_HELP_STRING([--disable-execinfo],
     [disable libexecinfo [[default=enable]]]),
@@ -68,7 +70,7 @@ AC_DEFINE(USER_AGENT, [std::string(PACKAGE "/" VERSION)], Http user agent)
 
 dnl Only update global build variables immediately before generating the output,
 dnl to avoid affecting the global build environment for other autoconf checks.
-LIBS="$PTHREAD_LIBS $CURSES_LIB $CURSES_LIBS $ZLIB_LIBS $DEPENDENCIES_LIBS $LIBS"
+LIBS="$ATOMIC_LIBS $PTHREAD_LIBS $CURSES_LIB $CURSES_LIBS $ZLIB_LIBS $DEPENDENCIES_LIBS $LIBS"
 CFLAGS="$CFLAGS $PTHREAD_CFLAGS $CURSES_CFLAGS $ZLIB_CFLAGS $DEPENDENCIES_CFLAGS"
 CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS $CURSES_CFLAGS $ZLIB_CFLAGS $DEPENDENCIES_CFLAGS"
 


### PR DESCRIPTION
Closes #1896.

`TORRENT_CHECK_ATOMIC` was added to `scripts/checks.m4` in 7537781, but nothing ever called it and `ATOMIC_LIBS` was never referenced anywhere, so the macro has been dead code and `-latomic` never reached the link line:

```
scripts/checks.m4:102   AC_DEFUN([TORRENT_CHECK_ATOMIC], ...)   computes and AC_SUBSTs ATOMIC_LIBS
configure.ac            never invoked it
*/Makefile.am           ATOMIC_LIBS never referenced
```

This wires it up the same way libtorrent does: call the macro alongside the other early checks, and put `$ATOMIC_LIBS` at the front of the `LIBS` line. Doing it through `LIBS` rather than a per-target `LDADD` means the test binaries are covered too.

## Where the 64-bit atomics come from

rtorrent's own headers only use `std::atomic<bool>`, `std::atomic<uint32_t>` and `std::atomic<unsigned int>`, which is why this is easy to miss. The 8-byte atomics arrive through a libtorrent public header:

```cpp
// torrent/runtime/memory_manager.h
std::atomic<uint64_t> m_memory_usage{};
std::atomic<uint64_t> m_max_memory_usage{};
std::atomic<uint64_t> m_sync_queue_memory_usage{};
```

The inline accessors on those members get emitted into rtorrent's own objects, which matches the reported undefined symbols landing in `main.o` and `command_local.o` specifically.

On targets where 64-bit atomics are lock-free the compiler emits instructions directly and nothing is needed. On 32-bit targets it emits calls to `__atomic_load_8` and friends, which live in libatomic.

## Testing

On a target that does not need it, the check reports `no`, `ATOMIC_LIBS` expands empty and the link line is unchanged:

```
checking whether 64-bit atomic operations require -latomic... no
```

`make check` passes, on the default configure and on `--with-xmlrpc-tinyxml2`.

I have no 32-bit machine to link against, so to confirm the plumbing actually carries a non-empty value I forced the macro to yield `-latomic` and re-ran configure. It reaches both the client and the test binaries:

```
src/Makefile:477   LIBS = -latomic -lpthread -lncurses -lz ... -ltorrent
test/Makefile:530  LIBS = -latomic -lpthread -lncurses -lz ... -ltorrent
```

@barracuda156 if you build this branch on ppc the check should now report `yes` and the link should resolve.
