### PR TITLE
Add system.sockets.<category>.min_alloc.limit.

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -259,6 +259,7 @@ initialize_command_local() {
     }
 
     CMD_ANY        (category_name + ".max_alloc.limit", [category](auto, auto) { return torrent::runtime::socket_manager()->category_alloc_limit(category); });
+    CMD_ANY        (category_name + ".min_alloc.limit", [category](auto, auto) { return torrent::runtime::socket_manager()->category_alloc_minimum(category); });
     CMD_ANY        (category_name + ".min_alloc",     [category](auto, auto) { return torrent::runtime::socket_manager()->category_min_allocation(category); });
     CMD_ANY        (category_name + ".max_alloc",     [category](auto, auto) { return torrent::runtime::socket_manager()->category_max_allocation(category); });
     CMD_ANY_VALUE_V(category_name + ".min_alloc.set", [category](auto, auto& value) { torrent::runtime::socket_manager()->set_category_min_allocation(category, value); });
@@ -372,6 +373,7 @@ initialize_command_local() {
     }
 
     rpc::rpc.mark_safe(category_name + ".max_alloc.limit");
+    rpc::rpc.mark_safe(category_name + ".min_alloc.limit");
     rpc::rpc.mark_safe(category_name + ".min_alloc");
     rpc::rpc.mark_safe(category_name + ".max_alloc");
   }


### PR DESCRIPTION
TL;DR A category can have a lower bound too, and a client needs to read it.

Depends on https://github.com/rakshasa/libtorrent/pull/877

  `<category>.max_alloc.limit` reports the upper bound a category will accept. A category can have a lower bound as well — the files category is limited to 4 and above, because `FileManager` refuses anything smaller — and a client has no way to read it.

  This registers `system.sockets.<category>.min_alloc.limit` alongside it, for the four configurable categories, marked safe.

  ```
  system.sockets.files.min_alloc.limit    = 4
  system.sockets.files.max_alloc.limit    = 65536
  system.sockets.http.min_alloc.limit     = 0
  system.sockets.http.max_alloc.limit     = 4096
  ```

  ruTorrent uses these to bound the two settings fields and explain a rejected value, rather than submitting one that fails.