### PR TITLE
ui: bound the input history size.

### DIFF
--- a/src/ui/root.cc
+++ b/src/ui/root.cc
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <stdexcept>
+#include <string>
 #include <string.h>
 #include <torrent/throttle.h>
 #include <torrent/torrent.h>
@@ -354,8 +355,9 @@ Root::reset_input_history_attributes(ui::DownloadList::Input type) {
 
 void
 Root::set_input_history_size(int size) {
-  if (size < 1)
-    throw torrent::input_error("Invalid input history size.");
+  if (size < 1 || size > max_input_history_size)
+    throw torrent::input_error("Input history size must be between 1 and " +
+                               std::to_string(max_input_history_size) + ".");
 
   for (auto& [entry, category] : m_input_history) {
     // Reserve the latest input history entries if new size is smaller than original.

--- a/src/ui/root.h
+++ b/src/ui/root.h
@@ -54,6 +54,11 @@ public:
   typedef std::vector<std::string> InputHistoryCategory;
   typedef std::map<int, InputHistoryCategory> InputHistory;
 
+  // Every category holds this many entries, and the whole history is written to
+  // and read back from the session, so the useful range ends long before the
+  // point where resizing it becomes a memory problem.
+  static constexpr int max_input_history_size = 4096;
+
   Root();
 
   void                init(Control* c);

--- a/src/ui/root.h
+++ b/src/ui/root.h
@@ -54,9 +54,6 @@ public:
   typedef std::vector<std::string> InputHistoryCategory;
   typedef std::map<int, InputHistoryCategory> InputHistory;
 
-  // Every category holds this many entries, and the whole history is written to
-  // and read back from the session, so the useful range ends long before the
-  // point where resizing it becomes a memory problem.
   static constexpr int max_input_history_size = 4096;
 
   Root();


### PR DESCRIPTION
TL;DR Only the lower end was checked, so a large value threw bad_alloc and exited.


  `ui.input.history.size.set` with a large value exits the client.

  `Root::set_input_history_size()` rejects anything below 1 but has no upper bound, and then resizes every input history category to the value given, so a large one throws `std::bad_alloc`. That is not a `local_error`, so the RPC layer does not turn it into a fault and the process
  exits.

  ```
  ui.input.history.size.set = 2147483647
  ```

  This bounds it at 4096, well above any usable input history, and folds the existing lower bound into the same message.

  | call | before | after |
  |---|---|---|
  | `= 2147483647` | `std::bad_alloc`, exit | fault, client alive |
  | `= 0` | fault | fault |
  | `= 200` | applied | applied |
