### PR TITLE
Do not fail startup on unreadable session files.

### DIFF
--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -35,8 +35,10 @@ is_network_uri(const std::string& uri) {
     std::strncmp(uri.c_str(), "ftp://", 6) == 0;
 }
 
+static constexpr const char* session_invalid_message = "Session data is invalid, ignoring it";
+
 static std::unique_ptr<torrent::Object>
-download_factory_load_stream(const char* filename) {
+download_factory_load_stream(const char* filename, bool* is_invalid) {
   std::fstream stream(filename, std::ios::in | std::ios::binary);
 
   if (!stream.is_open())
@@ -45,8 +47,10 @@ download_factory_load_stream(const char* filename) {
   auto obj = std::make_unique<torrent::Object>();
   stream >> *obj;
 
-  if (!stream.good())
+  if (!stream.good() || !obj->is_map()) {
+    *is_invalid = true;
     return std::unique_ptr<torrent::Object>();
+  }
 
   return obj;
 }
@@ -161,8 +165,13 @@ DownloadFactory::receive_commit() {
 
 void
 DownloadFactory::receive_success() {
-  auto rtorrent_object          = download_factory_load_stream((expand_path(m_uri) + ".rtorrent").c_str());
-  auto libtorrent_resume_object = download_factory_load_stream((expand_path(m_uri) + ".libtorrent_resume").c_str());
+  bool session_invalid = false;
+
+  auto rtorrent_object          = download_factory_load_stream((expand_path(m_uri) + ".rtorrent").c_str(), &session_invalid);
+  auto libtorrent_resume_object = download_factory_load_stream((expand_path(m_uri) + ".libtorrent_resume").c_str(), &session_invalid);
+
+  if (session_invalid)
+    lt_log_print(torrent::LOG_ERROR, "%s: %s", session_invalid_message, m_uri.c_str());
 
   uint32_t tracker_key;
 
@@ -182,6 +191,14 @@ DownloadFactory::receive_success() {
     // the log.
     m_slot_finished();
     return;
+  }
+
+  if (session_invalid) {
+    download->set_hash_failed(true);
+    download->set_message(session_invalid_message);
+
+    if (m_printLog)
+      m_manager->push_log_std(std::string(session_invalid_message) + ": \"" + m_uri + "\"");
   }
 
   torrent::Object* root = download->bencode();
@@ -274,9 +291,22 @@ DownloadFactory::receive_success() {
 
   rpc::call_command("d.peer_exchange.set", torrent::runtime::client_config()->is_pex_enabled(), rpc::make_target(download));
 
-  torrent::resume_load_addresses(*download->download(), resumeObject);
-  torrent::resume_load_file_priorities(*download->download(), resumeObject);
-  torrent::resume_load_tracker_settings(*download->download(), resumeObject);
+  try {
+    torrent::resume_load_addresses(*download->download(), resumeObject);
+    torrent::resume_load_file_priorities(*download->download(), resumeObject);
+    torrent::resume_load_tracker_settings(*download->download(), resumeObject);
+
+  } catch (const torrent::input_error& e) {
+    std::string msg = std::string(session_invalid_message) + ": " + e.what();
+
+    lt_log_print(torrent::LOG_ERROR, "%s: %s", msg.c_str(), m_uri.c_str());
+
+    if (m_printLog)
+      m_manager->push_log_std(msg + ": \"" + m_uri + "\"");
+
+    download->set_hash_failed(true);
+    download->set_message(msg);
+  }
 
   // The action of inserting might cause the torrent to be
   // opened/started or such. Figure out a nicer way of handling this.


### PR DESCRIPTION
TL;DR In anything in  the session directory gets corrupted for any reason, you're going to have a hard time recovering... often the only solution is just remove all the state files so that they can be rebuilt. I think it's best to make an effort to recover from the bad situation rather than crashing.

A session file that cannot be read currently produces one of two bad outcomes,  depending on how it is damaged.

If the file parses as valid bencode of the wrong type  (`le`, `i5e`), `receive_success()` throws `bencode_error` and rtorrent exits 255.  Nothing rewrites the file, so this repeats at **every** start — the daemon will  not boot until the file is located and deleted by hand.

If the file fails to parse at all — truncated,  bit-flipped, zeroed, random bytes — `download_factory_load_stream()` returns a
 null pointer, which is exactly what it returns when the file *does not exist*. The torrent then loads with all state reverted to defaults: the download  directory falls back to `directory.default` and `complete` drops to 0, with  nothing logged and nothing on the torrent.

  ## Testing

  16 corruptions of one good 664-byte `.rtorrent` file, deterministic (`seed=1234`),
  stock and patched built from the same tree. `directory.default` was set to a
  different path than the session's so state loss is observable.

  | variant | stock | patched |
  |---|---|---|
  | good (control) | starts | starts, no message |
  | empty file | starts, silent, state lost | flagged + logged |
  | `le` / `i5e` | **exit 255, every start** | flagged + logged |
  | truncated 50% / 25% / 1 byte / −1 byte | starts, silent, state lost | flagged + logged |
  | bit flip breaking a length prefix | starts, silent, state lost | flagged + logged |
  | 16 random bytes mid-file | starts, silent, state lost | flagged + logged |
  | whole file from `/dev/urandom` | starts, silent, state lost | flagged + logged |
  | all NUL bytes | starts, silent, state lost | flagged + logged |
