### PR TITLE
Close the connection when an SCGI header does not fit the buffer.

### DIFF
--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -94,8 +94,12 @@ SCgiTask::event_read() {
   if (m_content_length == 0)
     read_length--;
 
-  if (read_length <= 0)
+  if (read_length <= 0) {
+    if (m_content_length == 0)
+      return close();
+
     throw torrent::internal_error("SCgiTask::event_read() no space in buffer for event_read.");
+  }
 
   int bytes = ::recv(file_descriptor(), m_buffer.data() + m_position, read_length, 0);
 


### PR DESCRIPTION
TL;DR A malformed header aborted the process from the SCGI thread.

**Repro**

  Against master `224f06f`, default configuration:

  ```
  python3 -c "
  import socket
  s = socket.create_connection(('127.0.0.1', RPC_PORT))
  s.sendall(b'A' * 9000)"
  ```

  The daemon aborts. `b'9' * 9000` does the same through the other branch.

**Long version**
`SCgiTask::event_read()` throws `internal_error` when the buffer has no room
  left. During the header phase that condition is reachable from the network: a
  request whose netstring header never completes keeps being buffered until the
  8192-byte buffer is full, and the next read throws.

  ```
  terminate called after throwing an instance of 'torrent::internal_error'
    what():  SCgiTask::event_read() no space in buffer for event_read.
  ```

  The throw happens on the SCGI thread, where nothing catches it, so this is
  `std::terminate` → SIGABRT, not a graceful shutdown. One connection and 9000
  bytes are enough; the request is never dispatched, so this happens regardless of
  the trust check.


