### PR TITLE
Catch every json exception when processing a JSONRPC request.

### DIFF
--- a/src/rpc/jsonrpc.cc
+++ b/src/rpc/jsonrpc.cc
@@ -258,11 +258,8 @@ JsonRpc::process(const char* in_buffer, uint32_t length, slot_write callback) {
 
     return callback(response_str.c_str(), response_str.size());
 
-  } catch (json::parse_error& e) {
-    auto err_str = json_error(JSONRPC_PARSE_ERROR, e.what(), nullptr).dump(-1, ' ', false, json::error_handler_t::replace);
-    return callback(err_str.c_str(), err_str.size());
-  } catch (json::type_error& e) {
-    // Type errors may be caused by invalid UTF-8 strings in exception strings, hence the ::replace
+  } catch (json::exception& e) {
+    // Exception strings may contain invalid UTF-8, hence the ::replace
     auto err_str = json_error(JSONRPC_PARSE_ERROR, e.what(), nullptr).dump(-1, ' ', false, json::error_handler_t::replace);
     return callback(err_str.c_str(), err_str.size());
   }


### PR DESCRIPTION
TL;DR A number overflow escaped the two handlers and killed the process.

  `JsonRpc::process` handles `json::parse_error` and `json::type_error`. nlohmann
  derives three more exception types from `json::exception` — `out_of_range`,
  `invalid_iterator` and `other_error` — and those escape and terminate the process.

  A request body of `[1e999]` is enough:

  ```
  rtorrent: caught N8nlohmann...out_of_range : [json.exception.out_of_range.406] number overflow
  ```

  Catching the common base covers the overflow case and the other two types, and
  the response is the same shape it already produced for a parse error.

 **Testing**

  `[1e999]`, and the same literal inside an object, now return
  `{"error":{"code":-32700,"message":"[json.exception.out_of_range.406] number overflow ..."}}`
  with the daemon still running. A valid request still returns its result, and
  malformed JSON still returns a parse error.