### PR TITLE
Check the focus iterator before dereferencing it on erase.

### DIFF
--- a/src/ui/download_list.cc
+++ b/src/ui/download_list.cc
@@ -89,7 +89,7 @@ DownloadList::unfocus_download(core::Download* d) {
   if (m_state == DISPLAY_DOWNLOAD && d == static_cast<Download*>(m_uiArray[DISPLAY_DOWNLOAD])->download())
     activate_display(DISPLAY_DOWNLOAD_LIST);
 
-  if (*current_view()->focus() == d && current_view()->focus() < current_view()->end_visible())
+  if (current_view()->focus() < current_view()->end_visible() && *current_view()->focus() == d)
       current_view()->next_focus();
 }
 


### PR DESCRIPTION
TL;DR Erasing a download read past the end of the view.

**Repro**

  Against master `224f06f` built with ASan, add a torrent and erase it:

  ```
  ==ERROR: AddressSanitizer: heap-buffer-overflow
  READ of size 8
      #0 ui::DownloadList::unfocus_download(core::Download*) ui/download_list.cc:92
      #1 cmd_ui_unfocus_download(core::Download*) src/command_ui.cc:584
  ```

  Erasing the only download, the first of four, and the last of four all abort.
  On a release build this is an 8-byte read past the end feeding a pointer
  comparison rather than a visible failure.


  `DownloadList::unfocus_download()` reads the focused download before checking
  that focus is in range:

  ```cpp
  if (*current_view()->focus() == d && current_view()->focus() < current_view()->end_visible())
  ```

  The dereference is the left operand, so it happens first. `focus()` can equal
  `end_visible()` — that is the normal rolled-over state — and the read then goes
  past the end of the view.

  Every other place in the same file gets the order right, checking
  `focus() == end_visible()` before dereferencing (lines 141, 298, 309). This
  swaps the two operands so the bounds check runs first.

  `event.download.erased` is bound to `ui.unfocus_download` by default, so any
  `d.erase` reaches this, including with `system.daemon` set and no rc entries of
  your own.