### PR TITLE
Let the choke group list own its groups.

### DIFF
--- a/src/command_groups.cc
+++ b/src/command_groups.cc
@@ -1,5 +1,7 @@
 #include "config.h"
 
+#include <memory>
+
 #include <torrent/download/resource_manager.h>
 #include <torrent/download/choke_group.h>
 #include <torrent/download/choke_queue.h>
@@ -111,7 +113,7 @@ apply_cg_all_update_balance(bool is_up) {
 //
 #else
 
-std::vector<torrent::choke_group*> cg_list_hack;
+std::vector<std::unique_ptr<torrent::choke_group>> cg_list_hack;
 
 int64_t
 cg_get_index(const torrent::Object& raw_args) {
@@ -121,7 +123,7 @@ cg_get_index(const torrent::Object& raw_args) {
 
   if (arg.is_string()) {
     if (!rpc::parse_whole_value_nothrow(arg.as_string().c_str(), &index)) {
-      auto itr = std::find_if(cg_list_hack.begin(), cg_list_hack.end(), [&arg](torrent::choke_group* cg) { return arg.as_string() == cg->name(); });
+      auto itr = std::find_if(cg_list_hack.begin(), cg_list_hack.end(), [&arg](const auto& cg) { return arg.as_string() == cg->name(); });
 
       if (itr == cg_list_hack.end())
         throw torrent::input_error("Choke group not found.");
@@ -149,7 +151,7 @@ cg_get_group(const torrent::Object& raw_args) {
   if ((size_t)index >= cg_list_hack.size())
     throw torrent::input_error("Choke group not found.");
 
-  return cg_list_hack.at(index);
+  return cg_list_hack.at(index).get();
 }
 
 int64_t cg_d_group(core::Download* download) { return download->group(); }
@@ -162,7 +164,7 @@ torrent::Object
 apply_cg_list() {
   torrent::Object::list_type result;
 
-  for (auto itr : cg_list_hack)
+  for (const auto& itr : cg_list_hack)
     result.push_back(itr->name());
 
   return torrent::Object::from_list(result);
@@ -180,10 +182,10 @@ apply_cg_insert(const std::string& arg) {
   if (rpc::parse_whole_value_nothrow(arg.c_str(), &dummy))
     throw torrent::input_error("Cannot use a value string as choke group name.");
 
-  if (arg.empty() || std::any_of(cg_list_hack.begin(), cg_list_hack.end(), [&arg](auto cg) { return arg == cg->name(); }))
+  if (arg.empty() || std::any_of(cg_list_hack.begin(), cg_list_hack.end(), [&arg](const auto& cg) { return arg == cg->name(); }))
     throw torrent::input_error("Duplicate name for choke group.");
 
-  cg_list_hack.push_back(new torrent::choke_group());
+  cg_list_hack.push_back(std::make_unique<torrent::choke_group>());
   cg_list_hack.back()->set_name(arg);
 
   cg_list_hack.back()->up_queue()->set_heuristics(torrent::HEURISTICS_UPLOAD_LEECH);
@@ -194,7 +196,7 @@ apply_cg_insert(const std::string& arg) {
 
 torrent::Object
 apply_cg_index_of(const std::string& arg) {
-  auto itr = std::find_if(cg_list_hack.begin(), cg_list_hack.end(), [&arg](torrent::choke_group* cg) { return arg == cg->name(); });
+  auto itr = std::find_if(cg_list_hack.begin(), cg_list_hack.end(), [&arg](const auto& cg) { return arg == cg->name(); });
 
   if (itr == cg_list_hack.end())
     throw torrent::input_error("Choke group not found.");
@@ -206,7 +208,7 @@ torrent::Object
 apply_cg_all_update_balance(bool is_up) {
   LT_LOG_SUBSYSTEM("apply update balance: hack is_up:%i", (int)is_up);
 
-  for (auto itr : cg_list_hack) {
+  for (const auto& itr : cg_list_hack) {
     if (is_up)
       itr->up_queue()->balance();
     else
@@ -346,7 +348,7 @@ initialize_command_groups() {
 #else
   apply_cg_insert("default");
 
-  CMD_ANY         ("choke_group.size",                std::bind(&std::vector<torrent::choke_group*>::size, cg_list_hack));
+  CMD_ANY         ("choke_group.size",                [](auto, auto) { return (int64_t)cg_list_hack.size(); });
   CMD_ANY_STRING  ("choke_group.index_of",            std::bind(&apply_cg_index_of, std::placeholders::_2));
 #endif
 


### PR DESCRIPTION
TL;DR Each choke_group.insert leaked a group, and size reported a stale copy.

  `cg_list_hack` holds raw pointers from `new torrent::choke_group()` and nothing
  ever frees them, so every `choke_group.insert` loses a group. LeakSanitizer,
  after 20 calls:

  ```
  Direct leak of 6880 byte(s) in 20 object(s) allocated from:
    #1 apply_cg_insert(std::string const&)
  ```

  Making the vector hold `std::unique_ptr` gives the list ownership.

  That change also surfaces a second bug in the same registration:

  ```cpp
  CMD_ANY("choke_group.size", std::bind(&std::vector<torrent::choke_group*>::size, cg_list_hack));
  ```

  `std::bind` copies `cg_list_hack`, so `choke_group.size` answers from a snapshot
  taken at registration. After 20 inserts, `choke_group.list` returns 21 entries
  while `choke_group.size` still returns 1. A `unique_ptr` vector is not copyable,
  so this becomes a lambda over the live vector, and the two now agree.

