### PR TITLE
Limit the padding string.rpad and string.lpad will build.

### DIFF
--- a/src/command_string.cc
+++ b/src/command_string.cc
@@ -19,7 +19,7 @@
 
 namespace {
 
-constexpr int64_t max_string_pad_size = 1 << 20;
+constexpr int64_t max_string_pad_size = 1 << 14;
 
 const std::string whitespace_characters = " \t\n\r\f\v";
 

--- a/src/command_string.cc
+++ b/src/command_string.cc
@@ -19,6 +19,8 @@
 
 namespace {
 
+constexpr int64_t max_string_pad_size = 1 << 20;
+
 const std::string whitespace_characters = " \t\n\r\f\v";
 
 // The byte offset of every utf-8 character in 'text', terminated by the offset
@@ -249,10 +251,14 @@ apply_string_pad(const char* name, const torrent::Object::list_type& args, bool 
   if (pad_size <= text_length || padding.empty())
     return text;
 
+  if (pad_size - text_length > max_string_pad_size)
+    throw torrent::input_error(std::string(name) + ": padding is too large.");
+
   auto padding_offsets = utf8_offsets(padding);
   auto padding_length  = static_cast<int64_t>(padding_offsets.size() - 1);
 
   std::string result;
+  result.reserve(pad_size - text_length);
 
   for (int64_t i = 0; i < pad_size - text_length; i++) {
     auto index = static_cast<size_t>(i % padding_length);


### PR DESCRIPTION
TL;DR An untrusted caller could exhaust memory or the response limit.

Note - Unsure that this limit is sane, seems still incredibly high but it's what I saw in the code.


  `apply_string_pad` loops `pad_size - text_length` times, appending one character
  per iteration, with `pad_size` taken from the caller as an `int64_t`. Nothing
  bounds it, and both commands are in the `mark_safe` list, so an untrusted
  connection can call them.

  Two ways this ends the process, both from a request of a couple of hundred bytes:

  - `string.rpad("", "", 104857600)` builds a 100 MiB result, which trips the
    response guard in `SCgiTask::receive_write` (`length > (100 << 20)`) and throws
    `internal_error` — the daemon exits 255.
  - `string.rpad("", "", 1099511627776)` never gets that far. It allocates until it
    runs out; with the address space capped at 4 GB it reached the cap in about six
    seconds, so roughly 650 MB/s. Uncapped it walks the machine to exhaustion.
