### PR TITLE
Refuse a multicall whose commands change the download list.

### DIFF
--- a/src/command_events.cc
+++ b/src/command_events.cc
@@ -242,10 +242,16 @@ d_multicall(const torrent::Object::list_type& args) {
   torrent::Object             resultRaw = torrent::Object::create_list();
   torrent::Object::list_type& result = resultRaw.as_list();
 
+  auto* download_list  = control->core()->download_list();
+  auto  change_counter = download_list->change_counter();
+
   for (auto download : dlist) {
     torrent::Object::list_type& row = result.insert(result.end(), torrent::Object::create_list())->as_list();
 
     for (torrent::Object::list_const_iterator cItr = ++args.begin(); cItr != args.end(); cItr++) {
+      if (download_list->change_counter() != change_counter)
+        throw torrent::input_error("The download list changed during the multicall.");
+
       auto& cmd = cItr->as_string();
       row.push_back(rpc::parse_command(rpc::make_target(download), cmd.c_str(), cmd.c_str() + cmd.size()).first);
     }
@@ -278,12 +284,18 @@ d_multicall_filtered(const torrent::Object::list_type& args) {
 
   ++arg;  // skip to first command
 
+  auto* download_list  = control->core()->download_list();
+  auto  change_counter = download_list->change_counter();
+
   for (const auto& item : dlist) {
     // Add empty row to result
     torrent::Object::list_type& row = result.insert(result.end(), torrent::Object::create_list())->as_list();
 
     // Call the provided commands and assemble their results
     for (torrent::Object::list_const_iterator command = arg; command != args.end(); command++) {
+      if (download_list->change_counter() != change_counter)
+        throw torrent::input_error("The download list changed during the multicall.");
+
       auto& cmdstr = command->as_string();
       row.push_back(rpc::parse_command(rpc::make_target(item), cmdstr.c_str(), cmdstr.c_str() + cmdstr.size()).first);
     }

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -46,6 +46,8 @@ void
 DownloadList::clear() {
   int error_count = 0;
 
+  m_change_counter++;
+
   while (!empty()) {
     auto download = back();
 
@@ -161,6 +163,8 @@ DownloadList::iterator
 DownloadList::insert(Download* download) {
   iterator itr = base_type::insert(end(), download);
 
+  m_change_counter++;
+
   lt_log_print_info(torrent::LOG_TORRENT_INFO, download->info(), "download_list", "Inserting download.");
 
   try {
@@ -194,6 +198,8 @@ DownloadList::iterator
 DownloadList::erase(iterator itr) {
   if (itr == end())
     throw torrent::internal_error("DownloadList::erase(...) could not find download.");
+
+  m_change_counter++;
 
   lt_log_print_info(torrent::LOG_TORRENT_INFO, (*itr)->info(), "download_list", "Erasing download.");
 

--- a/src/core/download_list.h
+++ b/src/core/download_list.h
@@ -2,6 +2,7 @@
 #define RTORRENT_CORE_DOWNLOAD_LIST_H
 
 #include <iosfwd>
+#include <cstdint>
 #include <list>
 #include <string>
 
@@ -38,6 +39,10 @@ public:
 
   using base_type::empty;
   using base_type::size;
+
+  // Bumped whenever a download is added or removed, so an iteration over a
+  // snapshot of the list can tell that its pointers went stale.
+  uint32_t            change_counter() const                       { return m_change_counter; }
 
   DownloadList() = default;
 
@@ -129,6 +134,8 @@ private:
   void                confirm_finished(Download* d);
 
   void                process_meta_download(Download* d);
+
+  uint32_t            m_change_counter{0};
 };
 
 }


### PR DESCRIPTION
TL;DR Erasing a download left the loop dispatching on freed pointers.

  `d_multicall` copies the view into a `std::vector<core::Download*>` and then runs arbitrary command strings against each raw pointer. `DownloadList::erase` deletes  the download immediately, so a command that erases leaves the rest of the loop  dispatching on freed memory:

  ```
  ERROR: AddressSanitizer: heap-use-after-free  READ of size 8
    #0 torrent::Download::info() const            torrent/download.cc:33
    #2 initialize_command_download()::<lambda>    command_download.cc:668
  freed by thread T0 here:
    #1 core::DownloadList::erase(...)             core/download_list.cc:212
    #2 core::DownloadList::erase_ptr(...)         core/download_list.cc:190
  ```

  `d.multicall2("", "main", "d.erase=", "d.name=")` is enough — the erase and the
  read are in the same row. `d.multicall.filtered` has the same shape.

  `DownloadList` now carries a counter bumped whenever a download is inserted or removed, and both multicalls check it before each command, refusing with  `input_error` if the list moved. `clear()` needs its own bump because it does   `pop_back` and `delete` directly rather than going through `erase`.

**Note: Not totally sure of the implications - clearly the bug exists but is this the right solution?**
