### PR TITLE
Guard the unit multiplication in value commands against overflow.

### DIFF
--- a/src/rpc/command.cc
+++ b/src/rpc/command.cc
@@ -1,5 +1,7 @@
 #include "config.h"
 
+#include <limits>
+
 #include "core/download.h"
 #include "parse.h"
 
@@ -41,7 +43,13 @@ command_base_call_value_base(command_base* command_raw, target_type target, cons
     return command_base::_call<typename command_value_function<T>::type, T>(command_raw, target, val);
   }
 
-  return command_base::_call<typename command_value_function<T>::type, T>(command_raw, target, unit * arg.as_value());
+  auto value = arg.as_value();
+
+  if (value > std::numeric_limits<int64_t>::max() / unit ||
+      value < std::numeric_limits<int64_t>::min() / unit)
+    throw torrent::input_error("Value out of range.");
+
+  return command_base::_call<typename command_value_function<T>::type, T>(command_raw, target, unit * value);
 }
 
 template <typename T> const torrent::Object

--- a/src/rpc/parse.cc
+++ b/src/rpc/parse.cc
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <cstdio>
+#include <limits>
 #include <locale>
 #include <torrent/exceptions.h>
 
@@ -134,7 +135,13 @@ parse_value_nothrow(const char* src, int64_t* value, int base, int unit) {
 //   case ' ':
 //   case '\0': *value = *value * unit; break;
 //   default: throw torrent::input_error("Could not parse value.");
-  default: *value = *value * unit; break;
+  default:
+    if (*value > std::numeric_limits<int64_t>::max() / unit ||
+        *value < std::numeric_limits<int64_t>::min() / unit)
+      return src; // overflow guard
+
+    *value = *value * unit;
+    break;
   }
 
   return last;


### PR DESCRIPTION
TL;DR The kb variants multiply the argument by 1024 without checking the range.

command_base_call_value_base() multiplies the argument by the command's unit without any range check, so the kb variants overflow int64 once the value gets large enough. throttle.global_up.max_rate.set_kb with 2^53 is enough to take the process down.

The string path reaches the same multiplication through parse_value_nothrow(), which already guards the k/m/g suffixes but not the command's own unit, so both are checked now.

On master the i8 form dies with a deadly signal and the string form  ("99999999999999999999999") does the same; with the checks they return "Value out of range." and "Not a value.", while set_kb(100) still reads back 102400.
