### PR TITLE
Add a timeout to scgi tasks.

### DIFF
--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -14,6 +14,7 @@
 #include <torrent/runtime/socket_manager.h>
 #include <torrent/system/callbacks.h>
 #include <torrent/system/poll.h>
+#include <torrent/system/scheduler.h>
 #include <torrent/utils/log.h>
 
 #include "control.h"
@@ -26,6 +27,8 @@ namespace rpc {
 
 SCgiTask::SCgiTask()
   : m_callback_id(torrent::system::make_callback_id()) {
+
+  m_task_timeout.slot() = [this]() { close(); };
 
   reset_file_descriptor();
 }
@@ -50,6 +53,8 @@ SCgiTask::open(SCgi* parent, int fd) {
   torrent::this_thread::poll()->open(this);
   torrent::this_thread::poll()->insert_read(this);
 
+  torrent::this_thread::scheduler()->update_wait_for_ceil_seconds(&m_task_timeout, timeout_request);
+
   auto lock = std::lock_guard<std::mutex>(m_result_mutex);
 
   // Leave room for terminating nul byte for parsing the header.
@@ -61,6 +66,8 @@ SCgiTask::cancel_open() {
   if (!is_open())
     return;
 
+  torrent::this_thread::scheduler()->erase(&m_task_timeout);
+
   torrent::this_thread::poll()->remove_and_close(this);
 
   torrent::fd_close(file_descriptor());
@@ -71,6 +78,8 @@ void
 SCgiTask::close() {
   if (!is_open())
     return;
+
+  torrent::this_thread::scheduler()->erase(&m_task_timeout);
 
   torrent::system::cancel_callback_and_wait(m_callback_id, scgi_thread::thread(), torrent::main_thread::thread());
 
@@ -157,6 +166,8 @@ SCgiTask::event_read() {
     return;
 
   torrent::this_thread::poll()->remove_read(this);
+
+  torrent::this_thread::scheduler()->update_wait_for_ceil_seconds(&m_task_timeout, timeout_request);
 
   if (m_parent->log_fd() >= 0) {
     [[maybe_unused]] int result;

--- a/src/rpc/scgi_task.h
+++ b/src/rpc/scgi_task.h
@@ -1,10 +1,12 @@
 #ifndef RTORRENT_RPC_SCGI_TASK_H
 #define RTORRENT_RPC_SCGI_TASK_H
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <vector>
 #include <torrent/system/event.h>
+#include <torrent/system/scheduler.h>
 
 namespace rpc {
 
@@ -15,6 +17,8 @@ public:
   static constexpr int default_buffer_size = 8191;
   static constexpr int max_header_size     = 2000;
   static constexpr int max_content_size    = (2 << 23);
+
+  static constexpr auto timeout_request = std::chrono::seconds(60);
 
   enum ContentType { XML, JSON };
 
@@ -54,8 +58,9 @@ private:
   void                plaintext_response(const char* buffer, uint32_t content_length);
   void                gzip_response(const char* buffer, uint32_t content_length);
 
-  SCgi*                        m_parent{};
-  torrent::system::callback_id m_callback_id;
+  SCgi*                           m_parent{};
+  torrent::system::callback_id    m_callback_id;
+  torrent::system::SchedulerEntry m_task_timeout;
 
   std::mutex          m_result_mutex;
 


### PR DESCRIPTION
TL;DR A hundred connections sending a partial header held the whole task pool, causing the process to become unresponsive.

Each task now arms a SchedulerEntry when it is accepted and closes itself if the request has not arrived in time.

Selected timeout: 60 seconds (what seems reasonable to me, possibly too generous).

With a hundred held connections the rpc port is unreachable on master and still unreachable a minute later; with the timeout it starts answering again once the window passes.

Possible follow up - deny future connections from misbehaved clients.