### PR TITLE
Check flag_public_rpc when dispatching jsonrpc calls.

### DIFF
--- a/src/rpc/jsonrpc.cc
+++ b/src/rpc/jsonrpc.cc
@@ -138,7 +138,7 @@ jsonrpc_call_command(const std::string& method, const json& params) {
 
   CommandMap::iterator itr = commands.find(method.c_str());
 
-  if (itr == commands.end()) {
+  if (itr == commands.end() || !(itr->second.m_flags & CommandMap::flag_public_rpc)) {
     throw rpc_error(JSONRPC_METHOD_NOT_FOUND_ERROR, "method not found: " + method);
   }
 


### PR DESCRIPTION
Private commands and non-exported redirects were reachable over jsonrpc.

execute_command() in the xmlrpc backend refuses any method that is not marked flag_public_rpc, but jsonrpc_call_command() only checks that the method exists.