### PR TITLE
Mark view.list and system.time as untrusted safe.

### DIFF
--- a/src/command_local.cc
+++ b/src/command_local.cc
@@ -352,6 +352,9 @@ initialize_command_local() {
   rpc::rpc.mark_safe("system.api_version");
   rpc::rpc.mark_safe("system.client_version");
   rpc::rpc.mark_safe("system.library_version");
+  rpc::rpc.mark_safe("system.time");
+  rpc::rpc.mark_safe("system.time_seconds");
+  rpc::rpc.mark_safe("system.time_usec");
   rpc::rpc.mark_safe("system.file.max_size");
   rpc::rpc.mark_safe("system.file.split_size");
   rpc::rpc.mark_safe("system.file.split_suffix");

--- a/src/command_ui.cc
+++ b/src/command_ui.cc
@@ -916,6 +916,7 @@ initialize_command_ui() {
 
   rpc::rpc.mark_safe("view.set_visible");
   rpc::rpc.mark_safe("view.set_not_visible");
+  rpc::rpc.mark_safe("view.list");
 
   rpc::rpc.mark_safe("cat");
   rpc::rpc.mark_safe("if");


### PR DESCRIPTION
Both are read-only getters a client needs to list views and show relative times.