### PR TITLE
Run load command lists under the trust state of the submitting connection

### DIFF
--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -24,6 +24,7 @@
 #include "core/http_queue.h"
 #include "core/manager.h"
 #include "rpc/parse_commands.h"
+#include "rpc/rpc_manager.h"
 
 namespace core {
 
@@ -62,7 +63,8 @@ is_magnet_uri(const std::string& uri) {
 }
 
 DownloadFactory::DownloadFactory(Manager* m) :
-    m_manager(m) {
+    m_manager(m),
+    m_trusted(rpc::rpc.is_trusted()) {
 
   m_task_load.slot() = std::bind(&DownloadFactory::receive_load, this);
   m_task_commit.slot() = std::bind(&DownloadFactory::receive_commit, this);
@@ -325,8 +327,12 @@ DownloadFactory::receive_success() {
     if (torrent::log_groups[torrent::LOG_TORRENT_DEBUG].valid())
       log_created(download, rtorrent);
 
-    for (const auto& command : m_commands)
-      rpc::parse_command_multiple_std(command, rpc::make_target(download));
+    {
+      rpc::trust_scope scope(m_trusted);
+
+      for (const auto& command : m_commands)
+        rpc::parse_command_multiple_std(command, rpc::make_target(download));
+    }
 
     if (m_manager->download_list()->find(infohash) == m_manager->download_list()->end())
       throw torrent::input_error("The newly created download was removed.");

--- a/src/core/download_factory.h
+++ b/src/core/download_factory.h
@@ -75,6 +75,7 @@ private:
   bool                m_printLog{true};
   bool                m_isFile{};
   bool                m_initLoad{};
+  bool                m_trusted{true};
 
   command_list_type         m_commands;
   torrent::Object::map_type m_variables;

--- a/src/rpc/rpc_manager.cc
+++ b/src/rpc/rpc_manager.cc
@@ -135,17 +135,18 @@ RpcManager::process(RPCType type, const char* in_buffer, uint32_t length, slot_r
 
 bool
 RpcManager::process_untrusted(RPCType type, const char* in_buffer, uint32_t length, slot_response_callback callback) {
-  bool previous = m_trusted;
-  m_trusted = false;
+  trust_scope scope(false);
 
-  try {
-    bool result = process(type, in_buffer, length, callback);
-    m_trusted = previous;
-    return result;
-  } catch (...) {
-    m_trusted = previous;
-    throw;
-  }
+  return process(type, in_buffer, length, callback);
+}
+
+trust_scope::trust_scope(bool state) :
+    m_previous(rpc.is_trusted()) {
+  rpc.set_trusted(state);
+}
+
+trust_scope::~trust_scope() {
+  rpc.set_trusted(m_previous);
 }
 
 void

--- a/src/rpc/rpc_manager.h
+++ b/src/rpc/rpc_manager.h
@@ -99,6 +99,10 @@ public:
   static void         object_to_target(const torrent::Object& obj, int callFlags, rpc::target_type* target, std::function<void()>* deleter);
 
 private:
+  friend class trust_scope;
+
+  void          set_trusted(bool state) { m_trusted = state; }
+
   bool          m_trusted{true};
 
   XmlRpc        m_xmlrpc;
@@ -119,6 +123,18 @@ private:
 };
 
 extern RpcManager rpc;
+
+class trust_scope {
+public:
+  explicit trust_scope(bool state);
+  ~trust_scope();
+
+  trust_scope(const trust_scope&) = delete;
+  trust_scope& operator=(const trust_scope&) = delete;
+
+private:
+  bool          m_previous;
+};
 
 inline bool RpcManager::use_xmlrpc() const      { return m_use_xmlrpc; }
 inline void RpcManager::set_use_xmlrpc(bool v)  { m_use_xmlrpc = v; }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -46,7 +46,9 @@ rtorrent_Test_Rpc_SOURCES = $(rtorrent_Test_Common) \
 	rpc/test_object_storage.cc \
 	rpc/test_object_storage.h \
 	rpc/test_parse_options.cc \
-	rpc/test_parse_options.h
+	rpc/test_parse_options.h \
+	rpc/test_trust_scope.cc \
+	rpc/test_trust_scope.h
 
 rtorrent_Test_Src_SOURCES = $(rtorrent_Test_Common) \
 	src/test_command_dynamic.cc \

--- a/test/rpc/test_trust_scope.cc
+++ b/test/rpc/test_trust_scope.cc
@@ -1,0 +1,49 @@
+#include "config.h"
+
+#include "test/rpc/test_trust_scope.h"
+
+#include <torrent/exceptions.h>
+
+#include "rpc/rpc_manager.h"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestTrustScope);
+
+void
+TestTrustScope::test_basics() {
+  CPPUNIT_ASSERT(rpc::rpc.is_trusted());
+
+  {
+    rpc::trust_scope scope(false);
+
+    CPPUNIT_ASSERT(!rpc::rpc.is_trusted());
+  }
+
+  CPPUNIT_ASSERT(rpc::rpc.is_trusted());
+}
+
+void
+TestTrustScope::test_nested() {
+  rpc::trust_scope outer(false);
+
+  CPPUNIT_ASSERT(!rpc::rpc.is_trusted());
+
+  {
+    rpc::trust_scope inner(true);
+
+    CPPUNIT_ASSERT(rpc::rpc.is_trusted());
+  }
+
+  CPPUNIT_ASSERT(!rpc::rpc.is_trusted());
+}
+
+void
+TestTrustScope::test_exception() {
+  try {
+    rpc::trust_scope scope(false);
+
+    throw torrent::input_error("test");
+  } catch (torrent::input_error&) {
+  }
+
+  CPPUNIT_ASSERT(rpc::rpc.is_trusted());
+}

--- a/test/rpc/test_trust_scope.h
+++ b/test/rpc/test_trust_scope.h
@@ -1,0 +1,16 @@
+#include "test/helpers/test_fixture.h"
+
+class TestTrustScope : public test_fixture {
+  CPPUNIT_TEST_SUITE(TestTrustScope);
+
+  CPPUNIT_TEST(test_basics);
+  CPPUNIT_TEST(test_nested);
+  CPPUNIT_TEST(test_exception);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void test_basics();
+  void test_nested();
+  void test_exception();
+};


### PR DESCRIPTION
 process_untrusted() lowers the trusted flag, runs the request and restores it on one call stack, but DownloadFactory does not load on that stack: it defers to the  scheduler and returns. By the time receive_success() runs the command list attached to the load, the request is long finished and the flag is back to  trusted, so those commands run trusted however the request arrived.
 
DownloadFactory now records rpc.is_trusted() when it is constructed and re-enters  that state around the command loop through an RAII scope, which also restores on  the throwing paths out of receive_success(). Anything not created during an RPC  request - watch directories, session loads, .rtorrent.rc - is constructed while  trust is true and keeps running trusted. process_untrusted() uses the same scope  instead of its own save/restore.

Not currently reachable: load.* is not in the safe set, so this is latent until it is marked, which is the point of fixing it first. Verified by temporarily  marking load.raw_start safe and sending it untrusted with execute.capture=/bin/touch,<marker> attached: before, the marker appears; after,  the load still succeeds and the command is refused. Watch-dir and rc-driven loads still run their command lists, and load.* remains refused untrusted.