### PR TITLE
Add network.scgi.trusted for the default trust of SCGI connections

### DIFF
--- a/src/command_network.cc
+++ b/src/command_network.cc
@@ -413,6 +413,9 @@ initialize_command_network() {
   CMD_ANY         ("network.scgi.gzip.min_size",             [](auto, auto)                  { return rpc::rpc.scgi_min_compress_size(); });
   CMD_ANY_VALUE_V ("network.scgi.gzip.min_size.set",         [](auto, auto& arg)             { return rpc::rpc.set_scgi_min_compress_size(arg); });
 
+  CMD_ANY         ("network.scgi.trusted",                   [](auto, auto)                  { return rpc::rpc.scgi_trusted(); });
+  CMD_ANY_VALUE_V ("network.scgi.trusted.set",               [](auto, auto& arg)             { return rpc::rpc.set_scgi_trusted(arg); });
+
   CMD_ANY_STRING  ("network.xmlrpc.dialect.set",             [](auto, auto& arg)             { return apply_xmlrpc_dialect(arg); })
   CMD_ANY         ("network.xmlrpc.size_limit",              [](auto, auto)                  { return rpc::rpc.size_limit(); });
   CMD_ANY_VALUE_V ("network.xmlrpc.size_limit.set",          [](auto, auto& arg)             { return rpc::rpc.set_size_limit(arg); });

--- a/src/rpc/rpc_manager.h
+++ b/src/rpc/rpc_manager.h
@@ -85,6 +85,9 @@ public:
   unsigned int        scgi_min_compress_size() const                { return m_scgi_min_compress_size; }
   void                set_scgi_min_compress_size(unsigned int size) { m_scgi_min_compress_size = size; }
 
+  bool                scgi_trusted() const                          { return m_scgi_trusted; }
+  void                set_scgi_trusted(bool trusted)                { m_scgi_trusted = trusted; }
+
   slot_download&      slot_find_download() { return m_slot_find_download; }
   slot_file&          slot_find_file()     { return m_slot_find_file; }
   slot_tracker&       slot_find_tracker()  { return m_slot_find_tracker; }
@@ -110,6 +113,7 @@ private:
   bool          m_use_xmlrpc{true};
 
   std::atomic<bool>         m_scgi_allow_compression{true};
+  std::atomic<bool>         m_scgi_trusted{true};
   std::atomic<unsigned int> m_scgi_min_compress_size{1000};
 
   slot_download m_slot_find_download;

--- a/src/rpc/scgi_task.cc
+++ b/src/rpc/scgi_task.cc
@@ -42,10 +42,9 @@ SCgiTask::open(SCgi* parent, int fd) {
   m_content_type        = XML;
   m_content_type_set    = false;
   m_accepts_compression = false;
-  m_trusted             = true;  // SCgiTask is pooled and reused; reset trust to default
-                                 // so a prior untrusted connection does not leak its
-                                 // m_trusted=false into the next reuse, given that the
-                                 // UNTRUSTED_CONNECTION=0 parse branch is a no-op.
+  m_trusted             = rpc.scgi_trusted();  // SCgiTask is pooled and reused; reset trust to
+                                               // the configured default so a prior untrusted
+                                               // connection does not leak into the next reuse.
 
   torrent::this_thread::poll()->open(this);
   torrent::this_thread::poll()->insert_read(this);
@@ -252,8 +251,7 @@ SCgiTask::parse_headers(const char* current, unsigned int header_length) {
       if (std::strncmp(value, "1", 1+1) == 0)
         m_trusted = false;
       else if (std::strncmp(value, "0", 1+1) == 0)
-        m_trusted = true;  // Explicit reset (open() also resets, but be defensive in case
-                           // future refactors stop pooling tasks or skip the open() reset).
+        m_trusted = rpc.scgi_trusted();
       else
         return false;
     }


### PR DESCRIPTION
TL;DR - the current system, as is, is exploitable. ruTorrent's httprpc proxy sanitizes and that seems enough for clients that use that proxy, but transdroid and many others demand access to the RPC2 endpoint. I'm doing small steps towards locking down RPC2 without breaking clients. 

The untrusted-connection flag added in 5989149 can currently only be asserted by the client, via the UNTRUSTED_CONNECTION header. An operator has no way to state a posture: a connection starts trusted, and a client that sends nothing gets full access to every command. This adds the operator side of that decision.

 network.scgi.trusted.set = no makes SCGI connections start untrusted, so a reverse proxy that forgets the header — or a listener exposed by accident — no longer yields a trusted RPC endpoint. The default is true, so nothing changes unless it is configured.

 The header semantics change with it: UNTRUSTED_CONNECTION=1 still always lowers trust, but =0 now restores only as far as the configured default rather than unconditionally setting trusted. Without that, a client sends 0 and the setting has no effect.

network.scgi.trusted and .set are deliberately not marked untrusted-safe, so a connection cannot read or change its own trust level.

