### PR TITLE
Clamp the elapsed time conversion instead of overflowing.

### DIFF
--- a/src/command_ui.cc
+++ b/src/command_ui.cc
@@ -408,8 +408,9 @@ apply_to_time(const torrent::Object& rawArgs, int flags) {
 torrent::Object
 apply_to_elapsed_time(const torrent::Object& rawArgs) {
   auto cached_seconds = torrent::this_thread::cached_seconds().count();
+  auto value          = rawArgs.as_value();
 
-  uint64_t arg = cached_seconds - rawArgs.as_value();
+  uint64_t arg = value >= 0 && value <= cached_seconds ? cached_seconds - value : 0;
 
   char buffer[48];
   snprintf(buffer, 48, "%2d:%02d:%02d", (int)(arg / 3600), (int)((arg / 60) % 60), (int)(arg % 60));


### PR DESCRIPTION
apply_to_elapsed_time() subtracts the argument from the cached seconds with no  check, so a large negative value overflows: command_ui.cc:412 reports  "signed integer overflow: 1787327922 - -9223372036854775808 cannot be  represented in type 'long int'", and the process goes down on any build with  -fsanitize=undefined.


