### PR TITLE
Reject an XMLRPC size limit above the SCGI content size limit.

### DIFF
--- a/src/rpc/rpc_manager.cc
+++ b/src/rpc/rpc_manager.cc
@@ -168,6 +168,14 @@ RpcManager::cleanup() {
 }
 
 void
+RpcManager::set_size_limit(uint64_t size) {
+  if (size > SCgiTask::max_content_size)
+    throw torrent::input_error("XMLRPC size limit cannot exceed the SCGI content size limit.");
+
+  m_xmlrpc.set_size_limit(size);
+}
+
+void
 RpcManager::insert_command(const char* name, const char* parm, const char* doc) {
   m_xmlrpc.insert_command(name, parm, doc);
   m_jsonrpc.insert_command(name, parm, doc);

--- a/src/rpc/rpc_manager.h
+++ b/src/rpc/rpc_manager.h
@@ -62,7 +62,7 @@ public:
   void                cleanup();
 
   int64_t             size_limit()                  { return m_xmlrpc.size_limit(); };
-  void                set_size_limit(uint64_t size) { m_xmlrpc.set_size_limit(size); };
+  void                set_size_limit(uint64_t size);
 
   int                 dialect()                     { return m_xmlrpc.dialect(); }
   void                set_dialect(int dialect)      { m_xmlrpc.set_dialect(dialect); }

--- a/src/rpc/xmlrpc_c.cc
+++ b/src/rpc/xmlrpc_c.cc
@@ -529,9 +529,6 @@ XmlRpc::size_limit() {
 
 void
 XmlRpc::set_size_limit(uint64_t size) {
-  if (size >= (64 << 20))
-    throw torrent::input_error("Invalid XMLRPC limit size.");
-
   xmlrpc_limit_set(XMLRPC_XML_SIZE_LIMIT_ID, size);
 }
 


### PR DESCRIPTION
The ceiling on network.xmlrpc.size_limit.set was enforced inside xmlrpc_c.cc, so with the tinyxml2 backend there was no ceiling at all — and the limit it enforced (64 << 20) was unrelated to what actually bounds a request.
 
Move the check to RpcManager::set_size_limit, the funnel both backends pass through, and check against SCgiTask::max_content_size: a limit above that cannot take effect, since the request is refused before the XML is parsed.