### PR TITLE
Keep d.state and the started view in agreement when the core stops a download

### DIFF
--- a/src/command_download.cc
+++ b/src/command_download.cc
@@ -718,7 +718,7 @@ initialize_command_download() {
   CMD2_DL_V       ("d.pause",      std::bind(&core::DownloadList::pause_default, control->core()->download_list(), std::placeholders::_1));
   CMD2_DL_V       ("d.open",       std::bind(&core::DownloadList::open_throw, control->core()->download_list(), std::placeholders::_1));
   CMD2_DL_V       ("d.close",      std::bind(&core::DownloadList::close_throw, control->core()->download_list(), std::placeholders::_1));
-  CMD2_DL_V       ("d.close.directly", std::bind(&core::DownloadList::close_directly, control->core()->download_list(), std::placeholders::_1));
+  CMD2_DL_V       ("d.close.directly", std::bind(&core::DownloadList::close_files, control->core()->download_list(), std::placeholders::_1));
   CMD2_DL_V       ("d.erase",      std::bind(&core::DownloadList::erase_ptr, control->core()->download_list(), std::placeholders::_1));
   CMD2_DL_V       ("d.check_hash", std::bind(&core::DownloadList::check_hash, control->core()->download_list(), std::placeholders::_1));
 

--- a/src/core/download.cc
+++ b/src/core/download.cc
@@ -126,7 +126,7 @@ Download::set_root_directory(const std::string& path) {
     throw torrent::input_error("Cannot change the directory of an open download after the files have been moved.");
   }
 
-  control->core()->download_list()->close_directly(this);
+  control->core()->download_list()->close_files(this);
   file_list->set_root_dir(expand_path(path));
 
   bencode()->get_key("rtorrent").insert_key("directory", path);

--- a/src/core/download.cc
+++ b/src/core/download.cc
@@ -120,7 +120,6 @@ Download::set_root_directory(const std::string& path) {
        !file_stat.update(file_list->front()->frozen_path().str()))) {
 
     set_message("Cannot change the directory of an open download after the files have been moved.");
-    rpc::call_command("d.state.set", (int64_t)0, rpc::make_target(this));
     control->core()->download_list()->close_directly(this);
 
     throw torrent::input_error("Cannot change the directory of an open download after the files have been moved.");

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -554,7 +554,7 @@ DownloadList::hash_done(Download* download) {
     // If the download was previously completed but the files were
     // f.ex deleted, then we clear the state and complete.
     if (rpc::call_command_value("d.complete", rpc::make_target(download)) && !download->is_done()) {
-      rpc::call_command("d.state.set", (int64_t)0, rpc::make_target(download));
+      set_state_stopped(download);
       download->set_message("Download registered as completed, but hash check returned unfinished chunks.");
     }
 

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -275,7 +275,38 @@ void
 DownloadList::close_directly(Download* download) {
   lt_log_print_info(torrent::LOG_TORRENT_INFO, download->info(), "download_list", "Closing download directly.");
 
+  bool was_active = download->download()->info()->is_active();
+  bool was_open   = download->download()->info()->is_open();
+
   close_files(download);
+  set_state_stopped(download);
+
+  if (was_active) {
+    DL_TRIGGER_EVENT(download, "event.download.paused");
+    update_paused_state(download);
+  }
+
+  if (was_open) {
+    DL_TRIGGER_EVENT(download, "event.download.hash_removed");
+    DL_TRIGGER_EVENT(download, "event.download.closed");
+  }
+}
+
+void
+DownloadList::set_state_stopped(Download* download) {
+  control->view_manager()->find_ptr_throw("stopped")->set_visible(download);
+  rpc::call_command("d.state.set", (int64_t)0, rpc::make_target(download));
+}
+
+void
+DownloadList::update_paused_state(Download* download) {
+  rpc::call_command("d.state_changed.set", torrent::this_thread::cached_seconds().count(), rpc::make_target(download));
+  rpc::call_command("d.state_counter.set", rpc::call_command_value("d.state_counter", rpc::make_target(download)), rpc::make_target(download));
+
+  // If initial seeding is complete, don't try it again when restarting.
+  if (download->is_done() &&
+      rpc::call_command("d.connection_current", torrent::Object(), rpc::make_target(download)).as_string() == "initial_seed")
+    rpc::call_command("d.connection_seed.set", rpc::call_command("d.connection_current", torrent::Object(), rpc::make_target(download)), rpc::make_target(download));
 }
 
 void
@@ -452,15 +483,7 @@ DownloadList::pause(Download* download, int flags) {
     // view.
     DL_TRIGGER_EVENT(download, "event.download.paused");
 
-    auto cached_seconds = torrent::this_thread::cached_seconds().count();
-
-    rpc::call_command("d.state_changed.set", cached_seconds, rpc::make_target(download));
-    rpc::call_command("d.state_counter.set", rpc::call_command_value("d.state_counter", rpc::make_target(download)), rpc::make_target(download));
-
-    // If initial seeding is complete, don't try it again when restarting.
-    if (download->is_done() &&
-        rpc::call_command("d.connection_current", torrent::Object(), rpc::make_target(download)).as_string() == "initial_seed")
-      rpc::call_command("d.connection_seed.set", rpc::call_command("d.connection_current", torrent::Object(), rpc::make_target(download)), rpc::make_target(download));
+    update_paused_state(download);
 
     // Save the state after all the slots, etc have been called so we
     // include the modifications they may make.

--- a/src/core/download_list.cc
+++ b/src/core/download_list.cc
@@ -254,9 +254,11 @@ DownloadList::close(Download* download) {
   }
 }
 
+// Releases the files without changing the download's state, for callers that
+// need the files closed and will keep using the download.
 void
-DownloadList::close_directly(Download* download) {
-  lt_log_print_info(torrent::LOG_TORRENT_INFO, download->info(), "download_list", "Closing download directly.");
+DownloadList::close_files(Download* download) {
+  lt_log_print_info(torrent::LOG_TORRENT_INFO, download->info(), "download_list", "Closing download files.");
 
   if (download->download()->info()->is_active()) {
     download->download()->stop(torrent::Download::stop_skip_tracker);
@@ -267,6 +269,13 @@ DownloadList::close_directly(Download* download) {
 
   if (download->download()->info()->is_open())
     download->download()->close();
+}
+
+void
+DownloadList::close_directly(Download* download) {
+  lt_log_print_info(torrent::LOG_TORRENT_INFO, download->info(), "download_list", "Closing download directly.");
+
+  close_files(download);
 }
 
 void

--- a/src/core/download_list.h
+++ b/src/core/download_list.h
@@ -133,6 +133,9 @@ private:
   void                hash_done(Download* d);
   void                hash_queue(Download* d, int type);
 
+  void                set_state_stopped(Download* d);
+  void                update_paused_state(Download* d);
+
   inline void         check_contains(Download* d);
 
   void                received_finished(Download* d);

--- a/src/core/download_list.h
+++ b/src/core/download_list.h
@@ -75,6 +75,7 @@ public:
 
   void                close(Download* d);
   void                close_directly(Download* d);
+  void                close_files(Download* d);
   void                close_quick(Download* d);
   void                close_throw(Download* d);
 


### PR DESCRIPTION
Fixes #1958.

`hash_done()` and `set_root_directory()` cleared `d.state` while leaving the download in the `started` view. The variable is only set back to 1 by that view's `event_added`, which fires on entry, so a download that never left the view could not be started again: `View::set_visible()` returns early for one already visible, the event does not fire, and `d.start` is a no-op.

Following the review, the stopping now happens in `DownloadList::close_directly()`: it clears `d.state`, adds the download to the `stopped` view through the view rather than a parsed command, and ends with the events it used to swallow — `event.download.paused` when it was active, `hash_removed` and `closed` when it was open. The bookkeeping those share with `pause()` is now `update_paused_state()`, called from both. `hash_done()` does not close the download, so it reaches the same view and variable through the small `set_state_stopped()` the two share.

## Why close_files() exists

`close_directly()` had three callers, and only one of them means "stop this download":

- the refusal in `set_root_directory()`, which does mean it;
- the successful path of `set_root_directory()`, which only needs the files released before they are moved;
- the `d.close.directly` command, which closes files much as `d.close` does, and `d.close` does not clear `d.state` either.

Giving all three the stop would mean that changing a download's directory, or closing its files, also clears the flag that says the user wants it running. That flag is what survives a restart, so the download would come back stopped, and `d.close.directly` would part ways with `d.close`, which leaves it alone. The file-level half is therefore split out as `close_files()`, and the two callers that only need that use it. Their behaviour is unchanged.

## Verification

Two images built from the same context, differing only in the rtorrent source — master `c8da93b` and this branch — both against libtorrent master `4e0aebb`. The same completed torrent and session directory for every run.

    A  corrupt 4 MiB of a completed torrent's file, then open and start it
    B  rename the file away, then call d.directory.set
    C  call d.directory.set on a running download, with its files in place
    D  call d.close.directly on a running download

A and B then issue d.start three times. C and D are regression guards: they must pass before and after.

    check                                                  master   branch
    A  d.state agrees with the started view                  FAIL     PASS
    A  d.start restores d.state                              FAIL     PASS
    B  d.state agrees with the started view                  FAIL     PASS
    B  d.start restores d.state                              FAIL     PASS
    A/B  no other download changed state                     PASS     PASS
    C  a successful directory change does not stop it        PASS     PASS
    D  d.close.directly leaves d.state alone                 PASS     PASS

Recovery was also followed to the end on a live torrent: after the refused hash check the download is stopped, and once started it re-downloads the missing chunks, passes the completion hash check and returns to seeding on its own.
