### PR TITLE
add missing headers for libcxx-23

### DIFF
--- a/src/setup.h
+++ b/src/setup.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 int  parse_main_options(int argc, char** argv);
 void parse_config_file(int argc, char** argv, std::function<void (const std::string&)> parse_fn);


### PR DESCRIPTION
Starting with libcxx-23 transitive headers are being removed from their C++ standard library.